### PR TITLE
fix no_std support

### DIFF
--- a/audioadapter/Cargo.toml
+++ b/audioadapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.74"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]
@@ -16,10 +16,10 @@ default = ["audio"]
 audio = ["audio-core"]
 test-utils = []
 
-
 [dependencies]
-num-traits = "0.2.15"
-audio-core = { version = "0.2.0", optional = true }
+num-traits = { version = "0.2.15", default-features = false }
+audio-core = { version = "0.2.0", default-features = false, optional = true }
+
 
 [dev-dependencies]
 audio = "0.2.0"

--- a/audioadapter/src/iterators.rs
+++ b/audioadapter/src/iterators.rs
@@ -211,7 +211,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
     use crate::tests::MinimalAdapter;
+    use alloc::vec;
 
     use super::*;
 

--- a/audioadapter/src/lib.rs
+++ b/audioadapter/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(all(not(feature = "test-utils"), not(test)), no_std)]
+#![no_std]
 
 /// The traits for accessing samples in buffers.
 mod traits;
@@ -18,7 +18,11 @@ pub mod audio;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod tests {
+    extern crate alloc;
+
     use crate::{Adapter, AdapterMut};
+    use alloc::vec;
+    use alloc::vec::Vec;
     use num_traits::Float;
 
     /// Minimal implementation of an Adapter based on a vec
@@ -83,7 +87,7 @@ pub mod tests {
     /// The sample type `T` must support `Default`, `Clone`, `PartialEq`, `Debug`, and be convertible to and from `usize`.
     pub fn test_adapter_mut_methods<'a, T>(buffer: &mut dyn AdapterMut<'a, T>)
     where
-        T: Default + Clone + PartialEq + std::fmt::Debug + From<usize> + Into<usize> + 'a,
+        T: Default + Clone + PartialEq + core::fmt::Debug + From<usize> + Into<usize> + 'a,
     {
         // Ensure buffer is large enough for tests
         assert!(
@@ -196,7 +200,7 @@ pub mod tests {
     /// The sample type `T` must be a float that supports `Default`, `Clone`, `PartialEq`, and `Debug`.
     pub fn test_float_adapter_mut_methods<'a, T>(buffer: &mut dyn AdapterMut<'a, T>)
     where
-        T: Float + Default + Clone + PartialEq + std::fmt::Debug + 'a,
+        T: Float + Default + Clone + PartialEq + core::fmt::Debug + 'a,
     {
         // Helper for approximate float comparison
         let assert_approx_eq = |a: T, b: T, message: &str| {
@@ -213,7 +217,7 @@ pub mod tests {
         let assert_slice_approx_eq = |a: &[T], b: &[T], message: &str| {
             assert_eq!(a.len(), b.len(), "{} (slice lengths differ)", message);
             for (i, (val_a, val_b)) in a.iter().zip(b.iter()).enumerate() {
-                let msg = format!("{} (element {})", message, i);
+                let msg = alloc::format!("{} (element {})", message, i);
                 assert_approx_eq(*val_a, *val_b, &msg);
             }
         };

--- a/audioadapter/src/stats.rs
+++ b/audioadapter/src/stats.rs
@@ -116,8 +116,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
     use crate::stats::AdapterStats;
     use crate::tests::MinimalAdapter;
+    use alloc::vec;
 
     #[test]
     fn stats_integer() {

--- a/audioadapter/src/traits.rs
+++ b/audioadapter/src/traits.rs
@@ -386,8 +386,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
     use crate::tests::MinimalAdapter;
     use crate::{Adapter, AdapterMut};
+    use alloc::vec;
 
     fn dummy_adapter() -> MinimalAdapter<i32> {
         let data = vec![1_i32, 1, 2, 3, 4, 5, 6, 7];


### PR DESCRIPTION
The `audioadapter` crate doesn't properly support no_std because it doesn't disable the `std` feature in its `num-traits` and `audio-core` dependencies.

I also made the tests in `audioadapter` no_std compatible.