### PR TITLE
remove libm as a hard dependency

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,7 +25,7 @@ jobs:
         run: cargo test
 
       - name: Run audioadapter no-default-features tests
-        run: cargo test -p audioadapter --no-default-features
+        run: cargo test -p audioadapter --no-default-features --features "libm"
 
   lints:
     name: Lints

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,16 +16,16 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run cargo check
-        run: cargo check
+        run: cargo check --workspace
 
       - name: Run cargo check no features
-        run: cargo check --no-default-features
+        run: cargo check --workspace --no-default-features --features "audioadapter/libm, audioadapter-sample/libm, audioadapter-buffers/libm"
 
       - name: Run cargo test
-        run: cargo test
+        run: cargo test --workspace
 
-      - name: Run audioadapter no-default-features tests
-        run: cargo test -p audioadapter --no-default-features --features "libm"
+      - name: Run cargo no-default-features tests
+        run: cargo test --workspace --no-default-features --features "audioadapter/libm, audioadapter-sample/libm, audioadapter-buffers/libm"
 
   lints:
     name: Lints

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,9 @@ jobs:
           components: rustfmt, clippy
 
       - name: Publish audioadapter crate
-        run: cargo publish -p audioadapter --token ${CARGO_REGISTRY_TOKEN}
+        # Adding a default "std" feature to this crate would be a breaking change,
+        # so instead just enable the libm feature when performing the compile test.
+        run: cargo publish -p audioadapter --features "libm" --token ${CARGO_REGISTRY_TOKEN}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 resolver = "3"
 members = ["audioadapter", "audioadapter-buffers", "audioadapter-sample"]
+
+[workspace.dependencies]
+num-traits = { version = "0.2.15", default-features = false }
+audio-core = { version = "0.2.0", default-features = false }

--- a/audioadapter-buffers/Cargo.toml
+++ b/audioadapter-buffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter-buffers"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.74"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]
@@ -13,17 +13,19 @@ readme = "README.md"
 
 [features]
 default = ["std"]
-std = ["audioadapter-sample/std"]
+std = ["audioadapter-sample/std", "num-traits/std", "alloc"]
+libm = ["audioadapter/libm", "audioadapter-sample/libm"]
+alloc = []
 
 [dependencies]
-num-traits = "0.2.15"
-audioadapter = { version = "2.0.0", path = "../audioadapter" }
-audioadapter-sample = { version = "2.0.0", path = "../audioadapter-sample", default-features = false, features = ["audio"] }
+num-traits.workspace = true
+audioadapter = { version = "2.0.2", path = "../audioadapter" }
+audioadapter-sample = { version = "2.0.1", path = "../audioadapter-sample", default-features = false, features = ["audio"] }
 
 
 [dev-dependencies]
 criterion = "0.6"
-audioadapter = { version = "2.0.0", path = "../audioadapter", features = ["test-utils"]}
+audioadapter = { version = "2.0.2", path = "../audioadapter", features = ["test-utils"]}
 
 [[bench]]
 name = "iteration"

--- a/audioadapter-buffers/README.md
+++ b/audioadapter-buffers/README.md
@@ -90,8 +90,7 @@ This is handled by selecting `I24_4RJ_LE` or `I24_4LJ_LE` as the format.
 
 ## Use without the standard library
 This crate can be used in `no_std` environments if the `std` Cargo feature is disabled.
-This feature is enabled by default.
-Disabling it also disables all functionality that depends on the standard library,
-such as the buffers in the [owned] module since they are based on [std::vec::Vec].
+The `libm` feature must be enabled when the `std` feature is disabled.
+You can also enable the `alloc` feature to get the buffer types in the [owned] module.
 
 ## License: MIT

--- a/audioadapter-buffers/src/direct.rs
+++ b/audioadapter-buffers/src/direct.rs
@@ -39,13 +39,15 @@
 //! ```
 //!
 
-use crate::SizeError;
-
 use crate::slicetools::copy_within_slice;
+use crate::SizeError;
 use crate::{check_slice_length, implement_size_getters};
 use audioadapter::{Adapter, AdapterMut};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+#[cfg(feature = "alloc")]
 macro_rules! check_slice_and_vec_length {
     ($buf:expr, $channels:expr, $frames:expr, sequential) => {
         if $buf.len() < $channels {
@@ -114,14 +116,14 @@ macro_rules! check_slice_and_vec_length {
 
 /// Wrapper for a slice of length `channels`, containing vectors of length `frames`.
 /// Each vector contains the samples for all frames of one channel.
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub struct SequentialSliceOfVecs<U> {
     buf: U,
     frames: usize,
     channels: usize,
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> SequentialSliceOfVecs<&'a [Vec<T>]> {
     /// Create a new `SequentialSliceOfVecs` to wrap a slice of vectors.
     /// The slice must contain at least `channels` vectors,
@@ -139,7 +141,7 @@ impl<'a, T> SequentialSliceOfVecs<&'a [Vec<T>]> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> SequentialSliceOfVecs<&'a mut [Vec<T>]> {
     /// Create a new `SequentialSliceOfVecs` to wrap a mutable slice of vectors.
     /// The slice must contain at least `channels` vectors,
@@ -161,7 +163,7 @@ impl<'a, T> SequentialSliceOfVecs<&'a mut [Vec<T>]> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> Adapter<'a, T> for SequentialSliceOfVecs<&'a [Vec<T>]>
 where
     T: Clone,
@@ -186,7 +188,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> Adapter<'a, T> for SequentialSliceOfVecs<&'a mut [Vec<T>]>
 where
     T: Clone,
@@ -211,7 +213,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> AdapterMut<'a, T> for SequentialSliceOfVecs<&'a mut [Vec<T>]>
 where
     T: Clone,
@@ -300,7 +302,7 @@ where
 /// but here vectors for unused channels may be empty.
 /// Reading from an unused channel returns `T::default()`,
 /// while writing does nothing.
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub struct SparseSequentialSliceOfVecs<U> {
     buf: U,
     frames: usize,
@@ -308,7 +310,7 @@ pub struct SparseSequentialSliceOfVecs<U> {
     mask: Vec<bool>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> SparseSequentialSliceOfVecs<&'a [Vec<T>]> {
     /// Create a new `SparseSequentialSliceOfVecs` to wrap a slice of vectors.
     /// The slice must contain at least `channels` vectors.
@@ -335,7 +337,7 @@ impl<'a, T> SparseSequentialSliceOfVecs<&'a [Vec<T>]> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> SparseSequentialSliceOfVecs<&'a mut [Vec<T>]> {
     /// Create a new `SparseSequentialSliceOfVecs` to wrap a mutable slice of vectors.
     /// The slice must contain at least `channels` vectors,
@@ -360,7 +362,7 @@ impl<'a, T> SparseSequentialSliceOfVecs<&'a mut [Vec<T>]> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> Adapter<'a, T> for SparseSequentialSliceOfVecs<&'a [Vec<T>]>
 where
     T: Clone + Default,
@@ -388,7 +390,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> Adapter<'a, T> for SparseSequentialSliceOfVecs<&'a mut [Vec<T>]>
 where
     T: Clone + Default,
@@ -416,7 +418,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> AdapterMut<'a, T> for SparseSequentialSliceOfVecs<&'a mut [Vec<T>]>
 where
     T: Clone + Default,
@@ -509,14 +511,14 @@ where
 
 /// Wrapper for a slice of length `frames`, containing vectors of length `channels`.
 /// Each vector contains the samples for all channels of one frame.
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub struct InterleavedSliceOfVecs<U> {
     buf: U,
     frames: usize,
     channels: usize,
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> InterleavedSliceOfVecs<&'a [Vec<T>]> {
     /// Create a new `InterleavedSliceOfVecs` to wrap a slice of vectors.
     /// The slice must contain at least `frames` vectors,
@@ -534,7 +536,7 @@ impl<'a, T> InterleavedSliceOfVecs<&'a [Vec<T>]> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> InterleavedSliceOfVecs<&'a mut [Vec<T>]> {
     /// Create a new `InterleavedSliceOfVecs` to wrap a mutable slice of vectors.
     /// The slice must contain at least `frames` vectors,
@@ -556,7 +558,7 @@ impl<'a, T> InterleavedSliceOfVecs<&'a mut [Vec<T>]> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> Adapter<'a, T> for InterleavedSliceOfVecs<&'a [Vec<T>]>
 where
     T: Clone,
@@ -582,7 +584,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> Adapter<'a, T> for InterleavedSliceOfVecs<&'a mut [Vec<T>]>
 where
     T: Clone,
@@ -608,7 +610,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a, T> AdapterMut<'a, T> for InterleavedSliceOfVecs<&'a mut [Vec<T>]>
 where
     T: Clone,
@@ -1072,6 +1074,11 @@ where
 mod tests {
     use super::*;
     use audioadapter::tests::test_adapter_mut_methods;
+    extern crate alloc;
+    use alloc::vec;
+
+    #[cfg(feature = "alloc")]
+    use alloc::boxed::Box;
 
     fn insert_data(buffer: &mut dyn AdapterMut<i32>) {
         buffer.write_sample(0, 0, &1).unwrap();
@@ -1146,7 +1153,7 @@ mod tests {
         assert_eq!(buffer.read_sample(1, 2).unwrap(), 6);
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[test]
     fn vec_of_channels() {
         let mut data = vec![vec![0_i32; 3], vec![0_i32; 3]];
@@ -1158,7 +1165,7 @@ mod tests {
         test_mut_slice_frame(&mut buffer);
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[test]
     fn vec_of_frames() {
         let mut data = vec![vec![1_i32, 4], vec![2_i32, 5], vec![3, 6]];
@@ -1193,7 +1200,7 @@ mod tests {
     }
 
     // This tests that an Adapter is object safe.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[test]
     fn boxed_buffer() {
         let mut data = [1_i32, 2, 3, 4, 5, 6];
@@ -1210,9 +1217,9 @@ mod tests {
         fn is_sync<T: Sync>() {}
         is_send::<InterleavedSlice<f32>>();
         is_sync::<InterleavedSlice<f32>>();
-        #[cfg(feature = "std")]
+        #[cfg(feature = "alloc")]
         is_send::<InterleavedSliceOfVecs<f32>>();
-        #[cfg(feature = "std")]
+        #[cfg(feature = "alloc")]
         is_sync::<InterleavedSliceOfVecs<f32>>();
     }
 
@@ -1263,7 +1270,7 @@ mod tests {
         assert_eq!(data, expected);
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[test]
     fn sparse_sequential() {
         use audioadapter::stats::AdapterStats;
@@ -1306,7 +1313,7 @@ mod tests {
         check_copy_within(&mut adapter);
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[test]
     fn copy_within_interleaved_vecs() {
         let mut data = vec![vec![0; 2]; 10];
@@ -1314,7 +1321,7 @@ mod tests {
         check_copy_within(&mut adapter);
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[test]
     fn copy_within_sequential_vecs() {
         let mut data = vec![vec![0; 10]; 2];
@@ -1336,7 +1343,7 @@ mod tests {
         test_adapter_mut_methods(&mut buffer);
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_interleaved_slice_of_vecs_with_generic_tester() {
         let mut data = vec![vec![0usize; 2]; 4];
@@ -1344,7 +1351,7 @@ mod tests {
         test_adapter_mut_methods(&mut buffer);
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_sequential_slice_of_vecs_with_generic_tester() {
         let mut data = vec![vec![0usize; 4]; 2];
@@ -1352,7 +1359,7 @@ mod tests {
         test_adapter_mut_methods(&mut buffer);
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_sparse_sequential_slice_of_vecs_with_generic_tester() {
         let mut data = vec![vec![0usize; 4], vec![0usize; 4]];

--- a/audioadapter-buffers/src/lib.rs
+++ b/audioadapter-buffers/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 /// Wrappers providing direct access to samples in buffers.
 pub mod direct;
@@ -7,7 +10,7 @@ pub mod direct;
 /// stored both directly and as raw bytes.
 pub mod number_to_float;
 /// Wrappers that store their data in an owned vector.
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub mod owned;
 
 /// Dummy Adapter
@@ -15,10 +18,9 @@ pub mod dummy;
 
 mod slicetools;
 
-#[cfg(feature = "std")]
-use std::error::Error;
-#[cfg(feature = "std")]
-use std::fmt;
+use core::error::Error;
+use core::fmt;
+use core::write;
 
 pub mod adapter_to_float;
 
@@ -46,18 +48,17 @@ pub enum SizeError {
     },
 }
 
-#[cfg(feature = "std")]
 impl Error for SizeError {}
 
-#[cfg(feature = "std")]
 impl fmt::Display for SizeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let desc = match self {
+        match self {
             SizeError::Channel {
                 index,
                 actual,
                 required,
-            } => format!(
+            } => write!(
+                f,
                 "Buffer for channel {} is too short, got: {}, required: {}",
                 index, actual, required
             ),
@@ -65,20 +66,22 @@ impl fmt::Display for SizeError {
                 index,
                 actual,
                 required,
-            } => format!(
+            } => write!(
+                f,
                 "Buffer for frame {} is too short, got: {}, required: {}",
                 index, actual, required
             ),
-            SizeError::Total { actual, required } => format!(
+            SizeError::Total { actual, required } => write!(
+                f,
                 "Buffer is too short, got: {}, required: {}",
                 actual, required
             ),
-            SizeError::Mask { actual, required } => format!(
+            SizeError::Mask { actual, required } => write!(
+                f,
                 "Mask is wrong length, got: {}, required: {}",
                 actual, required
             ),
-        };
-        write!(f, "{}", &desc)
+        }
     }
 }
 

--- a/audioadapter-buffers/src/owned.rs
+++ b/audioadapter-buffers/src/owned.rs
@@ -36,10 +36,10 @@
 //! ```
 //!
 
-use crate::SizeError;
-
 use crate::slicetools::copy_within_slice;
+use crate::SizeError;
 use crate::{check_slice_length, implement_size_getters};
+use alloc::{vec, vec::Vec};
 use audioadapter::{Adapter, AdapterMut};
 
 //
@@ -386,6 +386,9 @@ where
 mod tests {
     use super::*;
     use audioadapter::tests::test_adapter_mut_methods;
+
+    #[cfg(feature = "alloc")]
+    use alloc::vec;
 
     fn insert_data(buffer: &mut dyn AdapterMut<i32>) {
         buffer.write_sample(0, 0, &1);

--- a/audioadapter-buffers/src/slicetools.rs
+++ b/audioadapter-buffers/src/slicetools.rs
@@ -39,6 +39,8 @@ pub unsafe fn copy_within_slice<T: Clone>(slice: &mut [T], src: usize, dest: usi
 #[cfg(test)]
 mod tests {
     use super::*;
+    extern crate alloc;
+    use alloc::{vec, vec::Vec};
 
     #[test]
     fn copy_forward_no_overlap() {

--- a/audioadapter-sample/Cargo.toml
+++ b/audioadapter-sample/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter-sample"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.74"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]
@@ -13,10 +13,11 @@ readme = "README.md"
 
 [features]
 default = ["std", "audio"]
-std = []
-audio = ["audio-core"]
+std = ["num-traits/std", "audio-core?/std"]
+libm = ["num-traits/libm"]
+audio = ["dep:audio-core"]
 
 [dependencies]
-num-traits = "0.2.15"
-audio-core = { version = "0.2.0", optional = true }
+num-traits.workspace = true
+audio-core = { workspace = true, optional = true }
 

--- a/audioadapter-sample/README.md
+++ b/audioadapter-sample/README.md
@@ -170,9 +170,12 @@ This is controlled by the `audio` feature which is enabled by default.
 
 ## Cargo features
 This crate has the following features:
- - `std` enables the standard library.
- - `audio` enables `audio` crate compatibility.
+ - `std` - enables the standard library (Enabled by default)
+ - `libm` - this must be enabled if `std` is disabled
+ - `audio` - enables `audio` crate compatibility (Enabled by default)
 
-Both features are enabled by default.
+## Use without the standard library
+This crate can be used in `no_std` environments if the `std` Cargo feature is disabled.
+The `libm` feature must be enabled when the `std` feature is disabled.
 
 ## License: MIT

--- a/audioadapter-sample/src/readwrite.rs
+++ b/audioadapter-sample/src/readwrite.rs
@@ -523,6 +523,8 @@ impl<W: io::Write + ?Sized> WriteSamples for W {}
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
     use super::*;
     use crate::readwrite::ReadSamples;
     use crate::readwrite::WriteSamples;

--- a/audioadapter/Cargo.toml
+++ b/audioadapter/Cargo.toml
@@ -19,8 +19,8 @@ libm = ["num-traits/libm"]
 test-utils = []
 
 [dependencies]
-num-traits = { version = "0.2.15", default-features = false }
-audio-core = { version = "0.2.0", default-features = false, optional = true }
+num-traits.workspace = true
+audio-core = { workspace = true, optional = true }
 
 [dev-dependencies]
 audio = "0.2.0"

--- a/audioadapter/Cargo.toml
+++ b/audioadapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.74"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]
@@ -14,13 +14,13 @@ readme = "README.md"
 [features]
 default = ["audio"]
 audio = ["audio-core"]
+libm = ["num-traits/libm"]
+
 test-utils = []
 
 [dependencies]
 num-traits = { version = "0.2.15", default-features = false }
-libm = { version = "0.2", default-features = false }
 audio-core = { version = "0.2.0", default-features = false, optional = true }
-
 
 [dev-dependencies]
 audio = "0.2.0"

--- a/audioadapter/README.md
+++ b/audioadapter/README.md
@@ -140,6 +140,7 @@ for a vector of strings.
 
 ## Using without the standard library
 The `audioadapter` traits do not require the standard library,
-and can therefore be used in `no_std` environments.
+and can therefore be used in `no_std` environments. However, the `libm` feature
+must be enabled when the `std` feature is disabled.
 
 ## License: MIT

--- a/audioadapter/src/stats.rs
+++ b/audioadapter/src/stats.rs
@@ -1,6 +1,6 @@
 use num_traits::{Num, ToPrimitive};
 
-// Rust analyzer itself always the standard library enabled,
+// Rust analyzer itself always has the standard library enabled,
 // which causes it to think this trait is not used.
 #[allow(unused)]
 use num_traits::Float;

--- a/audioadapter/src/stats.rs
+++ b/audioadapter/src/stats.rs
@@ -1,5 +1,10 @@
 use num_traits::{Num, ToPrimitive};
 
+// Rust analyzer itself always the standard library enabled,
+// which causes it to think this trait is not used.
+#[allow(unused)]
+use num_traits::Float;
+
 use crate::Adapter;
 
 /// A trait providing methods to calculate the RMS and peak-to-peak values of a channel or frame.
@@ -25,7 +30,7 @@ where
                 .unwrap_or_default();
             square_sum += sample * sample;
         }
-        libm::sqrt(square_sum / self.frames() as f64)
+        (square_sum / self.frames() as f64).sqrt()
     }
 
     /// Calculate the RMS value of the given channel.
@@ -43,7 +48,7 @@ where
                 .unwrap_or_default();
             square_sum += sample * sample;
         }
-        libm::sqrt(square_sum / self.channels() as f64)
+        (square_sum / self.channels() as f64).sqrt()
     }
 
     /// Calculate the peak-to-peak value of the given channel.


### PR DESCRIPTION
Thanks for publishing my last PR! Though there is still one small problem, which is that you added `libm` as a hard dependency of `audioadapter`. This is not ideal because it will cause the `libm` library to be included in the user's binary even when the standard library is enabled.

It would be a breaking change to add a default "std" feature to `audioadapter`, so instead I just made an optional "libm" feature that gets enabled when running the CI tests.