### PR TITLE
Make byte slice constructors sound, bump buffers to 4.0

### DIFF
--- a/audioadapter-buffers/Cargo.toml
+++ b/audioadapter-buffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter-buffers"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]

--- a/audioadapter-buffers/README.md
+++ b/audioadapter-buffers/README.md
@@ -88,6 +88,62 @@ stored as 3 bytes in little-endian order without padding.
 24-bit samples are also commonly stored with a padding byte, so that each sample takes up four bytes.
 This is handled by selecting `I24_4RJ_LE` or `I24_4LJ_LE` as the format.
 
+The sample format types such as `I24_LE` are re-exported from `audioadapter-sample`,
+so you can also reach them as `audioadapter_buffers::sample::I24_LE`
+without adding a separate dependency.
+
+### Example, write float values into a byte buffer
+The mutable constructors let you go the other way and write `f32` values
+into a buffer of raw bytes, converting on the fly.
+This writes interleaved 16-bit little-endian samples:
+
+```rust
+use audioadapter_buffers::number_to_float::InterleavedNumbers;
+use audioadapter_buffers::sample::I16_LE;
+use audioadapter::{Adapter, AdapterMut};
+
+// space for 2 channels * 3 frames * 2 bytes per sample => 12 bytes
+let mut data: Vec<u8> = vec![0; 12];
+
+// wrap the byte buffer for mutable access
+let mut buffer =
+    InterleavedNumbers::<&mut [I16_LE], f32>::new_from_bytes_mut(&mut data, 2, 3).unwrap();
+
+// write a value to every sample
+for channel in 0..buffer.channels() {
+    for frame in 0..buffer.frames() {
+        buffer.write_sample(channel, frame, &0.5).unwrap();
+    }
+}
+```
+
+## Wrapping existing buffers
+The [adapter_to_float] module wraps a buffer that already implements the
+`audioadapter` traits, adding on-the-fly conversion to and from float.
+Use `ConvertNumbers` for buffers of numeric samples,
+and `ConvertBytes` for buffers of raw byte arrays.
+
+### Example, read an existing i16 buffer as floats
+```rust
+use audioadapter::Adapter;
+use audioadapter_buffers::adapter_to_float::ConvertNumbers;
+use audioadapter_buffers::direct::InterleavedSlice;
+
+// Make a vector with some dummy data and wrap it as an interleaved i16 buffer.
+let data: Vec<i16> = vec![1, 2, 3, 4, 5, 6];
+let int_buffer = InterleavedSlice::new(&data, 2, 3).unwrap();
+
+// Wrap the buffer again with a converter to read the values as floats.
+let converter = ConvertNumbers::<_, f32>::new(&int_buffer as &dyn Adapter<i16>);
+
+for channel in 0..converter.channels() {
+    for frame in 0..converter.frames() {
+        let value = converter.read_sample(channel, frame).unwrap();
+        println!("Channel: {}, frame: {}, value: {}", channel, frame, value);
+    }
+}
+```
+
 ## Use without the standard library
 This crate can be used in `no_std` environments if the `std` Cargo feature is disabled.
 You can also enable the `alloc` feature to get the buffer types in the [owned] module.

--- a/audioadapter-buffers/src/adapter_to_float.rs
+++ b/audioadapter-buffers/src/adapter_to_float.rs
@@ -55,6 +55,15 @@ macro_rules! implement_wrapped_size_getters {
 /// A wrapper for an [Adapter] or [AdapterMut] buffer containing samples
 /// stored as byte arrays.
 /// The wrapper enables reading and writing the samples as floats.
+///
+/// # Type parameters
+/// - `T`: the floating point type that samples are converted to and from when
+///   reading and writing, for example `f32` or `f64`.
+/// - `U`: the byte-wrapper sample format type, for example [`I16_LE`] or
+///   [`F32_LE`]. It implements [BytesSample] and [RawSample], and determines the
+///   sample size as `[u8; U::BYTES_PER_SAMPLE]`.
+/// - `V`: the wrapped buffer type, an [Adapter] or [AdapterMut] over byte arrays
+///   of length `U::BYTES_PER_SAMPLE`.
 pub struct ConvertBytes<T, U, V>
 where
     T: FloatCore + ToPrimitive,
@@ -71,8 +80,11 @@ macro_rules! byte_convert_traits_newtype {
             where
                 T: FloatCore + ToPrimitive + 'a,
             {
-                #[doc = "Create a new wrapper for an [Adapter] buffer of byte arrays, `[u8;  U::BYTES_PER_SAMPLE ]`,"]
-                #[doc = "containing samples of type ` $typename `."]
+                #[doc = concat!(
+                    "Create a new wrapper for an [Adapter] buffer of byte arrays, `[u8; ",
+                    stringify!($typename), "::BYTES_PER_SAMPLE]`, containing samples of type [`",
+                    stringify!($typename), "`]."
+                )]
                 pub fn new(
                     buf: &'a dyn Adapter<'a, [u8; $typename::BYTES_PER_SAMPLE]>,
                 ) -> Self {
@@ -88,8 +100,11 @@ macro_rules! byte_convert_traits_newtype {
             where
                 T: FloatCore + ToPrimitive + 'a,
             {
-                #[doc = "Create a new wrapper for an mutable [AdapterMut] buffer of byte arrays, `[u8;  $bytes ]`,"]
-                #[doc = "containing samples of type ` $typename `."]
+                #[doc = concat!(
+                    "Create a new wrapper for a mutable [AdapterMut] buffer of byte arrays, `[u8; ",
+                    stringify!($typename), "::BYTES_PER_SAMPLE]`, containing samples of type [`",
+                    stringify!($typename), "`]."
+                )]
                 pub fn new_mut(
                     buf: &'a mut dyn AdapterMut<'a, [u8; $typename::BYTES_PER_SAMPLE]>,
                 ) -> Self {
@@ -195,6 +210,13 @@ byte_convert_traits_newtype!(F64_BE);
 /// A wrapper for an [Adapter] or [AdapterMut] buffer containing samples
 /// stored as numeric types.
 /// The wrapper enables reading and writing the samples as floats.
+///
+/// # Type parameters
+/// - `U`: the wrapped buffer type, an [Adapter] or [AdapterMut] over a numeric
+///   sample type, for example `&dyn Adapter<i16>`. The sample type implements
+///   [RawSample].
+/// - `V`: the floating point type that samples are converted to and from when
+///   reading and writing, for example `f32` or `f64`.
 pub struct ConvertNumbers<U, V> {
     _phantom: core::marker::PhantomData<V>,
     buf: U,

--- a/audioadapter-buffers/src/direct.rs
+++ b/audioadapter-buffers/src/direct.rs
@@ -240,7 +240,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for ch in self.buf.iter_mut() {
@@ -449,7 +449,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for (ch, active) in self.buf.iter_mut().zip(self.mask.iter()) {
@@ -633,7 +633,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for ch in self.buf.iter_mut() {
@@ -836,7 +836,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for (ch, active) in self.buf.iter_mut().zip(self.mask.iter()) {
@@ -1207,7 +1207,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         unsafe {
@@ -1404,7 +1404,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for ch in 0..self.channels {
@@ -1974,5 +1974,40 @@ mod tests {
             ),
             "expected SizeError::Mask with required length 2, got {err:?}"
         );
+    }
+
+    #[test]
+    fn overflowing_dimensions_are_rejected() {
+        // channels * frames overflows usize and must not wrap to a small
+        // value that passes the length check. See the soundness fix in
+        // `check_slice_length!`.
+        let data = [0_i32; 4];
+        // big * big wraps to exactly 0 (2^usize::BITS), which the unfixed check
+        // would treat as "required 0" and accept. Portable across 32/64-bit.
+        let big = 1_usize << (usize::BITS / 2);
+        assert!(
+            matches!(
+                InterleavedSlice::new(&data, big, big),
+                Err(SizeError::Total { .. })
+            ),
+            "overflowing channels * frames must be rejected"
+        );
+        assert!(
+            matches!(
+                SequentialSlice::new(&data, big, big),
+                Err(SizeError::Total { .. })
+            ),
+            "overflowing channels * frames must be rejected"
+        );
+    }
+
+    #[test]
+    fn copy_frames_within_rejects_overflowing_range() {
+        // src + count overflows usize. The guard must not wrap and allow an
+        // out-of-bounds copy.
+        let mut data = [0_i32; 6];
+        let mut buf = InterleavedSlice::new_mut(&mut data, 2, 3).unwrap();
+        assert_eq!(buf.copy_frames_within(usize::MAX, 0, 2), None);
+        assert_eq!(buf.copy_frames_within(0, usize::MAX, 2), None);
     }
 }

--- a/audioadapter-buffers/src/lib.rs
+++ b/audioadapter-buffers/src/lib.rs
@@ -141,18 +141,24 @@ pub(crate) use implement_size_getters;
 
 macro_rules! check_slice_length {
     ($channels:expr , $frames:expr, $length:expr ) => {
-        if $length < $frames * $channels {
+        // Saturating, so an overflowing product becomes `usize::MAX` and the
+        // check fails instead of wrapping to a small value and passing.
+        let required = $frames.saturating_mul($channels);
+        if $length < required {
             return Err(SizeError::Total {
                 actual: $length,
-                required: $frames * $channels,
+                required,
             });
         }
     };
     ($channels:expr , $frames:expr, $length:expr, $elements_per_sample:expr) => {
-        if $length < $frames * $channels * $elements_per_sample {
+        let required = $frames
+            .saturating_mul($channels)
+            .saturating_mul($elements_per_sample);
+        if $length < required {
             return Err(SizeError::Total {
                 actual: $length,
-                required: $frames * $channels * $elements_per_sample,
+                required,
             });
         }
     };

--- a/audioadapter-buffers/src/lib.rs
+++ b/audioadapter-buffers/src/lib.rs
@@ -16,6 +16,14 @@ pub mod owned;
 /// Dummy Adapter
 pub mod dummy;
 
+/// Sample format types re-exported from [`audioadapter_sample`].
+///
+/// These are the byte-wrapper types (`I16_LE`, `I24_LE`, `F32_LE`, …) used with
+/// the byte-based constructors and converters in [`number_to_float`] and
+/// [`adapter_to_float`]. They are re-exported here so that you do not need to add
+/// a separate dependency on `audioadapter-sample` just to name a format.
+pub use audioadapter_sample::sample;
+
 mod slicetools;
 
 use core::error::Error;

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -67,11 +67,15 @@ use crate::SizeError;
 use crate::slicetools::copy_within_slice;
 use crate::{check_slice_length, implement_size_getters};
 use audioadapter::{Adapter, AdapterMut};
-use audioadapter_sample::sample::RawSample;
+use audioadapter_sample::sample::{BytesSample, RawSample};
 
 /// A macro for creating a view of an immutable slice of bytes
 /// as a different type.
-#[macro_export]
+///
+/// This is **not** exported: it transmutes `&[u8]` into `&[$type]` with no
+/// trait bounds, so it is only sound for types with alignment 1 and no
+/// validity invariants. The internal call sites guarantee this by requiring
+/// `$type: BytesSample`, which is only implemented for such byte-wrapper types.
 macro_rules! byte_slice_as_type {
     ($slice:ident, $type:ty) => {
         unsafe {
@@ -84,7 +88,11 @@ macro_rules! byte_slice_as_type {
 
 /// A macro for creating a view of a mutable slice of bytes
 /// as a different type.
-#[macro_export]
+///
+/// This is **not** exported: it transmutes `&mut [u8]` into `&mut [$type]`
+/// with no trait bounds, so it is only sound for types with alignment 1 and
+/// no validity invariants. The internal call sites guarantee this by requiring
+/// `$type: BytesSample`, which is only implemented for such byte-wrapper types.
 macro_rules! byte_slice_as_type_mut {
     ($slice:ident, $type:ty) => {
         unsafe {
@@ -96,6 +104,13 @@ macro_rules! byte_slice_as_type_mut {
 }
 
 /// A wrapper for a slice containing interleaved numerical samples.
+///
+/// # Type parameters
+/// - `U`: the wrapped slice type holding the samples, for example `&[i16]`,
+///   `&mut [i16]`, or `&[I16_LE]` for the byte-based constructors. The element
+///   type implements [RawSample] (and [BytesSample] when constructing from bytes).
+/// - `V`: the floating point type that samples are converted to and from when
+///   reading and writing, for example `f32` or `f64`.
 pub struct InterleavedNumbers<U, V> {
     _phantom: core::marker::PhantomData<V>,
     buf: U,
@@ -103,7 +118,14 @@ pub struct InterleavedNumbers<U, V> {
     channels: usize,
 }
 
-/// A wrapper for a slice containing interleaved numerical samples.
+/// A wrapper for a slice containing sequential numerical samples.
+///
+/// # Type parameters
+/// - `U`: the wrapped slice type holding the samples, for example `&[i16]`,
+///   `&mut [i16]`, or `&[I16_LE]` for the byte-based constructors. The element
+///   type implements [RawSample] (and [BytesSample] when constructing from bytes).
+/// - `V`: the floating point type that samples are converted to and from when
+///   reading and writing, for example `f32` or `f64`.
 pub struct SequentialNumbers<U, V> {
     _phantom: core::marker::PhantomData<V>,
     buf: U,
@@ -144,8 +166,8 @@ where
         })
     }
 
-    /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [RawSample],
+    /// Create a new wrapper for an immutable slice
+    /// of numerical samples implementing [BytesSample],
     /// stored as raw bytes in _interleaved_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -155,7 +177,10 @@ where
         buf: &'a [u8],
         channels: usize,
         frames: usize,
-    ) -> Result<Self, SizeError> {
+    ) -> Result<Self, SizeError>
+    where
+        U: BytesSample,
+    {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type!(buf, U);
         Ok(Self {
@@ -190,7 +215,7 @@ where
     }
 
     /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [RawSample],
+    /// of numerical samples implementing [BytesSample],
     /// stored as raw bytes in _interleaved_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -200,7 +225,10 @@ where
         buf: &'a mut [u8],
         channels: usize,
         frames: usize,
-    ) -> Result<Self, SizeError> {
+    ) -> Result<Self, SizeError>
+    where
+        U: BytesSample,
+    {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type_mut!(buf, U);
         Ok(Self {
@@ -248,8 +276,8 @@ where
         })
     }
 
-    /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [RawSample],
+    /// Create a new wrapper for an immutable slice
+    /// of numerical samples implementing [BytesSample],
     /// stored as raw bytes in _sequential_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -259,7 +287,10 @@ where
         buf: &'a [u8],
         channels: usize,
         frames: usize,
-    ) -> Result<Self, SizeError> {
+    ) -> Result<Self, SizeError>
+    where
+        U: BytesSample,
+    {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type!(buf, U);
         Ok(Self {
@@ -294,7 +325,7 @@ where
     }
 
     /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [RawSample],
+    /// of numerical samples implementing [BytesSample],
     /// stored as raw bytes in _sequential_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -304,7 +335,10 @@ where
         buf: &'a mut [u8],
         channels: usize,
         frames: usize,
-    ) -> Result<Self, SizeError> {
+    ) -> Result<Self, SizeError>
+    where
+        U: BytesSample,
+    {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type_mut!(buf, U);
         Ok(Self {

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -173,11 +173,7 @@ where
     /// It is allowed to be longer than needed,
     /// but these extra values cannot
     /// be accessed via the `Adapter` trait methods.
-    pub fn new_from_bytes(
-        buf: &'a [u8],
-        channels: usize,
-        frames: usize,
-    ) -> Result<Self, SizeError>
+    pub fn new_from_bytes(buf: &'a [u8], channels: usize, frames: usize) -> Result<Self, SizeError>
     where
         U: BytesSample,
     {
@@ -283,11 +279,7 @@ where
     /// It is allowed to be longer than needed,
     /// but these extra values cannot
     /// be accessed via the `Adapter` trait methods.
-    pub fn new_from_bytes(
-        buf: &'a [u8],
-        channels: usize,
-        frames: usize,
-    ) -> Result<Self, SizeError>
+    pub fn new_from_bytes(buf: &'a [u8], channels: usize, frames: usize) -> Result<Self, SizeError>
     where
         U: BytesSample,
     {

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -72,13 +72,20 @@ use audioadapter_sample::sample::{BytesSample, RawSample};
 /// A macro for creating a view of an immutable slice of bytes
 /// as a different type.
 ///
-/// This is **not** exported: it transmutes `&[u8]` into `&[$type]` with no
-/// trait bounds, so it is only sound for types with alignment 1 and no
-/// validity invariants. The internal call sites guarantee this by requiring
-/// `$type: BytesSample`, which is only implemented for such byte-wrapper types.
+/// This is **not** exported: it transmutes `&[u8]` into `&[$type]`, which is
+/// only sound for types with alignment 1 and no validity invariants. Alignment
+/// is verified at compile time by the `const` assert below, and the internal
+/// call sites only ever use the library's `BytesSample` byte-wrapper types,
+/// which are `[u8; N]` newtypes where every bit pattern is valid.
 macro_rules! byte_slice_as_type {
     ($slice:ident, $type:ty) => {
         unsafe {
+            const {
+                assert!(
+                    core::mem::align_of::<$type>() == 1,
+                    "type must have alignment 1"
+                )
+            };
             let ptr = $slice.as_ptr() as *const $type;
             let len = $slice.len();
             core::slice::from_raw_parts(ptr, len / core::mem::size_of::<$type>())
@@ -89,13 +96,20 @@ macro_rules! byte_slice_as_type {
 /// A macro for creating a view of a mutable slice of bytes
 /// as a different type.
 ///
-/// This is **not** exported: it transmutes `&mut [u8]` into `&mut [$type]`
-/// with no trait bounds, so it is only sound for types with alignment 1 and
-/// no validity invariants. The internal call sites guarantee this by requiring
-/// `$type: BytesSample`, which is only implemented for such byte-wrapper types.
+/// This is **not** exported: it transmutes `&mut [u8]` into `&mut [$type]`,
+/// which is only sound for types with alignment 1 and no validity invariants.
+/// Alignment is verified at compile time by the `const` assert below, and the
+/// internal call sites only ever use the library's `BytesSample` byte-wrapper
+/// types, which are `[u8; N]` newtypes where every bit pattern is valid.
 macro_rules! byte_slice_as_type_mut {
     ($slice:ident, $type:ty) => {
         unsafe {
+            const {
+                assert!(
+                    core::mem::align_of::<$type>() == 1,
+                    "type must have alignment 1"
+                )
+            };
             let ptr = $slice.as_mut_ptr() as *mut $type;
             let len = $slice.len();
             core::slice::from_raw_parts_mut(ptr, len / core::mem::size_of::<$type>())

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -278,7 +278,7 @@ where
     }
 
     fn copy_frames_within_impl(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         unsafe {
@@ -384,7 +384,7 @@ where
     }
 
     fn copy_frames_within_impl(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for ch in 0..self.channels {

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -67,25 +67,23 @@ use crate::SizeError;
 use crate::slicetools::copy_within_slice;
 use crate::{check_slice_length, implement_size_getters};
 use audioadapter::{Adapter, AdapterMut};
-use audioadapter_sample::sample::{BytesSample, RawSample};
+use audioadapter_sample::sample::{
+    BytesSample, F32_BE, F32_LE, F64_BE, F64_LE, I16_BE, I16_LE, I24_4LJ_BE, I24_4LJ_LE,
+    I24_4RJ_BE, I24_4RJ_LE, I24_BE, I24_LE, I32_BE, I32_LE, I64_BE, I64_LE, RawSample, U16_BE,
+    U16_LE, U24_4LJ_BE, U24_4LJ_LE, U24_4RJ_BE, U24_4RJ_LE, U24_BE, U24_LE, U32_BE, U32_LE, U64_BE,
+    U64_LE,
+};
 
 /// A macro for creating a view of an immutable slice of bytes
 /// as a different type.
 ///
 /// This is **not** exported: it transmutes `&[u8]` into `&[$type]`, which is
-/// only sound for types with alignment 1 and no validity invariants. Alignment
-/// is verified at compile time by the `const` assert below, and the internal
-/// call sites only ever use the library's `BytesSample` byte-wrapper types,
-/// which are `[u8; N]` newtypes where every bit pattern is valid.
+/// only sound for types with alignment 1 and no validity invariants. Callers
+/// must therefore require `$type: PlainBytes`, whose unsafe contract guarantees
+/// exactly those properties.
 macro_rules! byte_slice_as_type {
     ($slice:ident, $type:ty) => {
         unsafe {
-            const {
-                assert!(
-                    core::mem::align_of::<$type>() == 1,
-                    "type must have alignment 1"
-                )
-            };
             let ptr = $slice.as_ptr() as *const $type;
             let len = $slice.len();
             core::slice::from_raw_parts(ptr, len / core::mem::size_of::<$type>())
@@ -98,18 +96,11 @@ macro_rules! byte_slice_as_type {
 ///
 /// This is **not** exported: it transmutes `&mut [u8]` into `&mut [$type]`,
 /// which is only sound for types with alignment 1 and no validity invariants.
-/// Alignment is verified at compile time by the `const` assert below, and the
-/// internal call sites only ever use the library's `BytesSample` byte-wrapper
-/// types, which are `[u8; N]` newtypes where every bit pattern is valid.
+/// Callers must therefore require `$type: PlainBytes`, whose unsafe contract
+/// guarantees exactly those properties.
 macro_rules! byte_slice_as_type_mut {
     ($slice:ident, $type:ty) => {
         unsafe {
-            const {
-                assert!(
-                    core::mem::align_of::<$type>() == 1,
-                    "type must have alignment 1"
-                )
-            };
             let ptr = $slice.as_mut_ptr() as *mut $type;
             let len = $slice.len();
             core::slice::from_raw_parts_mut(ptr, len / core::mem::size_of::<$type>())
@@ -117,12 +108,49 @@ macro_rules! byte_slice_as_type_mut {
     };
 }
 
+/// Marker trait for sample types whose raw byte representation can be viewed
+/// directly as the type, enabling the byte-based constructors.
+///
+/// # Safety
+/// The byte-based constructors
+/// ([`InterleavedNumbers::new_from_bytes`], [`InterleavedNumbers::new_from_bytes_mut`],
+/// [`SequentialNumbers::new_from_bytes`], [`SequentialNumbers::new_from_bytes_mut`])
+/// reinterpret a `&[u8]` as a `&[Self]` without copying. For that to be sound,
+/// every implementor must guarantee that:
+///
+/// - `Self` has an alignment of 1, and
+/// - every bit pattern of the matching size is a valid value of `Self`, i.e. it
+///   is a plain "bag of bytes" with no validity invariants and no padding.
+///
+/// All the byte-wrapper sample types in [`audioadapter_sample`] are
+/// `[u8; N]` newtypes that satisfy both requirements, and this trait is
+/// implemented for all of them. If you implement [BytesSample] for your own
+/// type and want to use it with those constructors, implement this trait too,
+/// upholding the requirements above.
+pub unsafe trait PlainBytes: BytesSample {}
+
+macro_rules! impl_plainbytes {
+    ($($t:ty),* $(,)?) => {
+        $(
+            // SAFETY: each type is a `#[derive(..)]` newtype around `[u8; N]`,
+            // which has alignment 1 and is valid for every bit pattern.
+            unsafe impl PlainBytes for $t {}
+        )*
+    };
+}
+
+impl_plainbytes!(
+    I16_LE, I16_BE, U16_LE, U16_BE, I24_LE, I24_BE, U24_LE, U24_BE, I24_4LJ_LE, I24_4LJ_BE,
+    I24_4RJ_LE, I24_4RJ_BE, U24_4LJ_LE, U24_4LJ_BE, U24_4RJ_LE, U24_4RJ_BE, I32_LE, I32_BE, U32_LE,
+    U32_BE, I64_LE, I64_BE, U64_LE, U64_BE, F32_LE, F32_BE, F64_LE, F64_BE,
+);
+
 /// A wrapper for a slice containing interleaved numerical samples.
 ///
 /// # Type parameters
 /// - `U`: the wrapped slice type holding the samples, for example `&[i16]`,
 ///   `&mut [i16]`, or `&[I16_LE]` for the byte-based constructors. The element
-///   type implements [RawSample] (and [BytesSample] when constructing from bytes).
+///   type implements [RawSample] (and [PlainBytes] when constructing from bytes).
 /// - `V`: the floating point type that samples are converted to and from when
 ///   reading and writing, for example `f32` or `f64`.
 pub struct InterleavedNumbers<U, V> {
@@ -137,7 +165,7 @@ pub struct InterleavedNumbers<U, V> {
 /// # Type parameters
 /// - `U`: the wrapped slice type holding the samples, for example `&[i16]`,
 ///   `&mut [i16]`, or `&[I16_LE]` for the byte-based constructors. The element
-///   type implements [RawSample] (and [BytesSample] when constructing from bytes).
+///   type implements [RawSample] (and [PlainBytes] when constructing from bytes).
 /// - `V`: the floating point type that samples are converted to and from when
 ///   reading and writing, for example `f32` or `f64`.
 pub struct SequentialNumbers<U, V> {
@@ -181,7 +209,7 @@ where
     }
 
     /// Create a new wrapper for an immutable slice
-    /// of numerical samples implementing [BytesSample],
+    /// of numerical samples implementing [PlainBytes],
     /// stored as raw bytes in _interleaved_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -189,7 +217,7 @@ where
     /// be accessed via the `Adapter` trait methods.
     pub fn new_from_bytes(buf: &'a [u8], channels: usize, frames: usize) -> Result<Self, SizeError>
     where
-        U: BytesSample,
+        U: PlainBytes,
     {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type!(buf, U);
@@ -225,7 +253,7 @@ where
     }
 
     /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [BytesSample],
+    /// of numerical samples implementing [PlainBytes],
     /// stored as raw bytes in _interleaved_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -237,7 +265,7 @@ where
         frames: usize,
     ) -> Result<Self, SizeError>
     where
-        U: BytesSample,
+        U: PlainBytes,
     {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type_mut!(buf, U);
@@ -287,7 +315,7 @@ where
     }
 
     /// Create a new wrapper for an immutable slice
-    /// of numerical samples implementing [BytesSample],
+    /// of numerical samples implementing [PlainBytes],
     /// stored as raw bytes in _sequential_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -295,7 +323,7 @@ where
     /// be accessed via the `Adapter` trait methods.
     pub fn new_from_bytes(buf: &'a [u8], channels: usize, frames: usize) -> Result<Self, SizeError>
     where
-        U: BytesSample,
+        U: PlainBytes,
     {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type!(buf, U);
@@ -331,7 +359,7 @@ where
     }
 
     /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [BytesSample],
+    /// of numerical samples implementing [PlainBytes],
     /// stored as raw bytes in _sequential_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -343,7 +371,7 @@ where
         frames: usize,
     ) -> Result<Self, SizeError>
     where
-        U: BytesSample,
+        U: PlainBytes,
     {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type_mut!(buf, U);

--- a/audioadapter-buffers/src/owned.rs
+++ b/audioadapter-buffers/src/owned.rs
@@ -69,8 +69,13 @@ where
     T: Clone,
 {
     /// Create a new `InterleavedOwned` by allocaing a new vector filled with `value`.
+    ///
+    /// Panics if `channels * frames` overflows `usize`.
     pub fn new(value: T, channels: usize, frames: usize) -> Self {
-        let buf = vec![value; channels * frames];
+        let len = channels
+            .checked_mul(frames)
+            .expect("channels * frames overflows usize");
+        let buf = vec![value; len];
         Self {
             buf,
             frames,
@@ -157,7 +162,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         unsafe {
@@ -239,8 +244,13 @@ where
     T: Clone,
 {
     /// Create a new `SequentialOwned` by allocaing a new vector filled with `value`.
+    ///
+    /// Panics if `channels * frames` overflows `usize`.
     pub fn new(value: T, channels: usize, frames: usize) -> Self {
-        let buf = vec![value; channels * frames];
+        let len = channels
+            .checked_mul(frames)
+            .expect("channels * frames overflows usize");
+        let buf = vec![value; len];
         Self {
             buf,
             frames,
@@ -327,7 +337,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for ch in 0..self.channels {
@@ -568,5 +578,21 @@ mod tests {
     fn test_sequential_owned_with_generic_tester() {
         let mut buffer = SequentialOwned::new(0usize, 2, 4);
         test_adapter_mut_methods(&mut buffer);
+    }
+
+    #[test]
+    #[should_panic(expected = "overflows usize")]
+    fn interleaved_owned_new_panics_on_overflow() {
+        // channels * frames overflows usize: must panic, not wrap to a small
+        // allocation while claiming the large dimensions.
+        let big = 1_usize << (usize::BITS / 2);
+        let _ = InterleavedOwned::new(0_i32, big, big);
+    }
+
+    #[test]
+    #[should_panic(expected = "overflows usize")]
+    fn sequential_owned_new_panics_on_overflow() {
+        let big = 1_usize << (usize::BITS / 2);
+        let _ = SequentialOwned::new(0_i32, big, big);
     }
 }


### PR DESCRIPTION
Add a BytesSample bound to new_from_bytes/new_from_bytes_mut and un-export the byte_slice_as_type macros so arbitrary types can no longer be transmuted from bytes. Also fix doc bugs, re-export the sample types, and expand the README.