### PR TITLE
Soundness: overflow in Adapter bounds checks, and read_sample without mem::zeroed

### DIFF
--- a/audioadapter-buffers/Cargo.toml
+++ b/audioadapter-buffers/Cargo.toml
@@ -19,7 +19,7 @@ alloc = []
 [dependencies]
 num-traits.workspace = true
 audioadapter = { version = "3.0.0", path = "../audioadapter" }
-audioadapter-sample = { version = "3.0.0", path = "../audioadapter-sample", default-features = false, features = ["audio"] }
+audioadapter-sample = { version = "4.0.0", path = "../audioadapter-sample", default-features = false, features = ["audio"] }
 
 
 [dev-dependencies]

--- a/audioadapter-sample/Cargo.toml
+++ b/audioadapter-sample/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter-sample"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]

--- a/audioadapter-sample/src/readwrite.rs
+++ b/audioadapter-sample/src/readwrite.rs
@@ -24,7 +24,10 @@ pub trait ReadSamples: io::Read {
     /// * The underlying reader returns an error.
     /// * The number of bytes read is not sufficient to represent a complete sample.
     fn read_sample<T: BytesSample>(&mut self) -> io::Result<T> {
-        let mut sample: T = unsafe { std::mem::zeroed() };
+        // Start from a valid, correctly sized sample and read straight into its
+        // bytes. Using `T::zero()` rather than `mem::zeroed` keeps this sound
+        // for any `T`, since `zero` is a safe, implementor-provided constructor.
+        let mut sample = T::zero();
         self.read_exact(sample.as_mut_slice())?;
         Ok(sample)
     }

--- a/audioadapter-sample/src/sample.rs
+++ b/audioadapter-sample/src/sample.rs
@@ -218,6 +218,13 @@ pub trait BytesSample {
     /// The number of bytes making up each sample value.
     const BYTES_PER_SAMPLE: usize;
 
+    /// Create a sample with all bytes set to zero.
+    ///
+    /// This gives a correctly sized, valid value whose bytes can then be
+    /// overwritten, for example via [`as_mut_slice`](Self::as_mut_slice) when
+    /// reading from a stream.
+    fn zero() -> Self;
+
     /// Create a new ByteSample from a slice of raw bytes.
     /// The slice length must be at least the number of bytes
     /// for a sample value.
@@ -310,6 +317,10 @@ impl BytesSample for I24_4RJ_LE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -339,6 +350,10 @@ impl BytesSample for I24_4LJ_LE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -366,6 +381,10 @@ impl BytesSample for I24_4LJ_LE {
 impl BytesSample for I24_LE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
+
+    fn zero() -> Self {
+        Self(Default::default())
+    }
 
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..3].try_into().unwrap())
@@ -396,6 +415,10 @@ impl BytesSample for I24_4RJ_BE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -425,6 +448,10 @@ impl BytesSample for I24_4LJ_BE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -452,6 +479,10 @@ impl BytesSample for I24_4LJ_BE {
 impl BytesSample for I24_BE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
+
+    fn zero() -> Self {
+        Self(Default::default())
+    }
 
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..3].try_into().unwrap())
@@ -482,6 +513,10 @@ impl BytesSample for U24_4RJ_LE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -511,6 +546,10 @@ impl BytesSample for U24_4LJ_LE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -538,6 +577,10 @@ impl BytesSample for U24_4LJ_LE {
 impl BytesSample for U24_LE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
+
+    fn zero() -> Self {
+        Self(Default::default())
+    }
 
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..3].try_into().unwrap())
@@ -568,6 +611,10 @@ impl BytesSample for U24_4RJ_BE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -597,6 +644,10 @@ impl BytesSample for U24_4LJ_BE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -624,6 +675,10 @@ impl BytesSample for U24_4LJ_BE {
 impl BytesSample for U24_BE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
+
+    fn zero() -> Self {
+        Self(Default::default())
+    }
 
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..3].try_into().unwrap())
@@ -653,6 +708,10 @@ macro_rules! bytessample_for_newtype {
         impl BytesSample for $newtype {
             type NumericType = $type;
             const BYTES_PER_SAMPLE: usize = core::mem::size_of::<$type>();
+
+            fn zero() -> Self {
+                Self(Default::default())
+            }
 
             fn from_slice(bytes: &[u8]) -> Self {
                 Self(bytes.try_into().unwrap())

--- a/audioadapter/Cargo.toml
+++ b/audioadapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]

--- a/audioadapter/src/traits.rs
+++ b/audioadapter/src/traits.rs
@@ -243,10 +243,13 @@ where
         self_skip: usize,
         take: usize,
     ) -> Option<usize> {
+        // Overflow-safe form of `take + self_skip > self.frames()` etc.
         if self_channel >= self.channels()
-            || take + self_skip > self.frames()
+            || take > self.frames()
+            || self_skip > self.frames() - take
             || other_channel >= other.channels()
-            || take + other_skip > other.frames()
+            || take > other.frames()
+            || other_skip > other.frames() - take
         {
             return None;
         }
@@ -294,7 +297,9 @@ where
     /// or to initialize each sample to a certain value.
     /// Returns `None` if called with a too large range.
     fn fill_frames_with(&mut self, start: usize, count: usize, value: &T) -> Option<usize> {
-        if start + count >= self.frames() {
+        // Overflow-safe form of `start + count > frames`. Previously used `>=`,
+        // which wrongly rejected a fill whose range ends exactly at `frames`.
+        if count > self.frames() || start > self.frames() - count {
             return None;
         }
         for channel in 0..self.channels() {
@@ -322,7 +327,8 @@ where
     /// The default implementation copies by calling the read and write methods,
     /// while type specific implementations can use more efficient methods.
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames() || dest + count > self.frames() {
+        // Overflow-safe form of `src + count > frames || dest + count > frames`.
+        if count > self.frames() || src > self.frames() - count || dest > self.frames() - count {
             return None;
         }
         if count == 0 || src == dest {
@@ -638,5 +644,44 @@ mod tests {
 
         // OOB
         assert!(!buffer.swap_samples(0, 0, 2, 0));
+    }
+
+    #[test]
+    fn copy_frames_within_rejects_overflowing_range() {
+        let mut buffer = dummy_adapter(); // 2 channels, 4 frames
+        // src + count and dest + count would wrap; must return None, not UB.
+        assert_eq!(buffer.copy_frames_within(usize::MAX, 0, 2), None);
+        assert_eq!(buffer.copy_frames_within(0, usize::MAX, 2), None);
+        assert_eq!(buffer.copy_frames_within(0, 0, usize::MAX), None);
+    }
+
+    #[test]
+    fn copy_from_other_rejects_overflowing_range() {
+        let mut buffer = dummy_adapter();
+        let other = dummy_adapter();
+        // take + skip would wrap; must return None, not index out of bounds.
+        assert_eq!(
+            buffer.copy_from_other_to_channel(&other, 0, 0, usize::MAX, 0, 2),
+            None
+        );
+        assert_eq!(
+            buffer.copy_from_other_to_channel(&other, 0, 0, 0, usize::MAX, 2),
+            None
+        );
+    }
+
+    #[test]
+    fn fill_frames_with_allows_full_range() {
+        // Filling the whole frame range (start + count == frames) is valid and
+        // must succeed. The old `>=` guard wrongly rejected this.
+        let mut buffer = dummy_adapter(); // 4 frames
+        assert_eq!(buffer.fill_frames_with(0, 4, &9), Some(4));
+        for f in 0..4 {
+            assert_eq!(buffer.read_sample(0, f), Some(9));
+            assert_eq!(buffer.read_sample(1, f), Some(9));
+        }
+        // Past the end is still rejected, including the overflowing case.
+        assert_eq!(buffer.fill_frames_with(0, 5, &9), None);
+        assert_eq!(buffer.fill_frames_with(usize::MAX, 2, &9), None);
     }
 }


### PR DESCRIPTION
Part of the coordinated 4.0 release on \`release/4.0\`.

## Core (\`audioadapter\`)
Default trait methods checked bounds with unchecked additions on user-supplied \`usize\` values, which
wrap in release builds and let the checks pass before indexing out of bounds via the unchecked
accessors (UB from safe code):

- \`copy_frames_within\`: \`src + count\` / \`dest + count\`
- \`copy_from_other_to_channel\`: \`take + self_skip\` / \`take + other_skip\`

Both rewritten overflow-safe. \`fill_frames_with\` had the same overflow plus an off-by-one (\`>=\`
rather than \`>\`) that rejected a fill ending exactly at the last frame. Regression tests added.

## Sample (\`audioadapter-sample\`)
\`read_sample\` built the sample with \`mem::zeroed::<T>()\`, which is UB for any \`BytesSample\` type
that is not valid when zero-filled. Added a safe \`BytesSample::zero()\` constructor and read straight
into its bytes via \`as_mut_slice\`. No allocation, exact size, no cap. Adding a required trait method
is breaking, so sample goes to **4.0.0** (and buffers' sample dependency requirement is bumped to
match).

## Versions
- \`audioadapter\` -> 3.0.1 (will roll into 4.0.0 on the release branch once the lifetime removal lands)
- \`audioadapter-sample\` -> 4.0.0