### PR TITLE
Remove vestigial 'a lifetime from Adapter and AdapterMut

### DIFF
--- a/audioadapter-buffers/Cargo.toml
+++ b/audioadapter-buffers/Cargo.toml
@@ -18,13 +18,13 @@ alloc = []
 
 [dependencies]
 num-traits.workspace = true
-audioadapter = { version = "3.0.0", path = "../audioadapter" }
+audioadapter = { version = "4.0.0", path = "../audioadapter" }
 audioadapter-sample = { version = "4.0.0", path = "../audioadapter-sample", default-features = false, features = ["audio"] }
 
 
 [dev-dependencies]
 criterion = "0.6"
-audioadapter = { version = "3.0.0", path = "../audioadapter", features = ["test-utils"]}
+audioadapter = { version = "4.0.0", path = "../audioadapter", features = ["test-utils"]}
 
 [[bench]]
 name = "iteration"

--- a/audioadapter-buffers/src/adapter_to_float.rs
+++ b/audioadapter-buffers/src/adapter_to_float.rs
@@ -78,7 +78,7 @@ macro_rules! byte_convert_traits_newtype {
     ($typename:ident) => {
         impl<'a, T> ConvertBytes<T, $typename, &'a dyn Adapter<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
-                T: FloatCore + ToPrimitive + 'a,
+                T: FloatCore + ToPrimitive,
             {
                 #[doc = concat!(
                     "Create a new wrapper for an [Adapter] buffer of byte arrays, `[u8; ",
@@ -98,7 +98,7 @@ macro_rules! byte_convert_traits_newtype {
 
             impl<'a, T> ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
-                T: FloatCore + ToPrimitive + 'a,
+                T: FloatCore + ToPrimitive,
             {
                 #[doc = concat!(
                     "Create a new wrapper for a mutable [AdapterMut] buffer of byte arrays, `[u8; ",
@@ -118,7 +118,7 @@ macro_rules! byte_convert_traits_newtype {
 
             unsafe impl<'a, T> Adapter<T> for ConvertBytes<T, $typename, &'a dyn Adapter<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
-            T: FloatCore + ToPrimitive + 'a,
+            T: FloatCore + ToPrimitive,
             {
                 unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
                     let raw = unsafe { self.buf.read_sample_unchecked(channel, frame) };
@@ -131,7 +131,7 @@ macro_rules! byte_convert_traits_newtype {
 
             unsafe impl<'a, T> Adapter<T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
-            T: FloatCore + ToPrimitive + 'a,
+            T: FloatCore + ToPrimitive,
             {
                 unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
                     let raw = unsafe { self.buf.read_sample_unchecked(channel, frame) };
@@ -144,7 +144,7 @@ macro_rules! byte_convert_traits_newtype {
 
             unsafe impl<'a, T> AdapterMut<T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
-            T: FloatCore + ToPrimitive + 'a,
+            T: FloatCore + ToPrimitive,
             {
                 unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &T) -> bool {
                     let converted = $typename::from_scaled_float(*value);
@@ -224,8 +224,8 @@ pub struct ConvertNumbers<U, V> {
 
 impl<'a, T, U> ConvertNumbers<&'a dyn Adapter<U>, T>
 where
-    T: FloatCore + ToPrimitive + 'a,
-    U: RawSample + 'a,
+    T: FloatCore + ToPrimitive,
+    U: RawSample,
 {
     /// Create a new wrapper for a buffer implementing the [Adapter] trait,
     /// containing numerical samples.
@@ -239,8 +239,8 @@ where
 
 impl<'a, T, U> ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
 where
-    T: FloatCore + ToPrimitive + 'a,
-    U: RawSample + 'a,
+    T: FloatCore + ToPrimitive,
+    U: RawSample,
 {
     /// Create a new wrapper for a mutable buffer implementing the [AdapterMut] trait,
     /// containing numerical samples.
@@ -252,10 +252,10 @@ where
     }
 }
 
-unsafe impl<'a, T, U> Adapter<T> for ConvertNumbers<&'a dyn Adapter<U>, T>
+unsafe impl<T, U> Adapter<T> for ConvertNumbers<&dyn Adapter<U>, T>
 where
-    T: FloatCore + ToPrimitive + 'a,
-    U: RawSample + 'a,
+    T: FloatCore + ToPrimitive,
+    U: RawSample,
 {
     unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
         unsafe {
@@ -268,10 +268,10 @@ where
     implement_wrapped_size_getters!();
 }
 
-unsafe impl<'a, T, U> Adapter<T> for ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
+unsafe impl<T, U> Adapter<T> for ConvertNumbers<&mut dyn AdapterMut<U>, T>
 where
-    T: FloatCore + ToPrimitive + 'a,
-    U: RawSample + 'a,
+    T: FloatCore + ToPrimitive,
+    U: RawSample,
 {
     unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
         unsafe {
@@ -284,10 +284,10 @@ where
     implement_wrapped_size_getters!();
 }
 
-unsafe impl<'a, T, U> AdapterMut<T> for ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
+unsafe impl<T, U> AdapterMut<T> for ConvertNumbers<&mut dyn AdapterMut<U>, T>
 where
-    T: FloatCore + ToPrimitive + 'a,
-    U: RawSample + Clone + 'a,
+    T: FloatCore + ToPrimitive,
+    U: RawSample + Clone,
 {
     unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &T) -> bool {
         let converted = U::from_scaled_float(*value);

--- a/audioadapter-buffers/src/adapter_to_float.rs
+++ b/audioadapter-buffers/src/adapter_to_float.rs
@@ -76,7 +76,7 @@ where
 
 macro_rules! byte_convert_traits_newtype {
     ($typename:ident) => {
-        impl<'a, T> ConvertBytes<T, $typename, &'a dyn Adapter<'a, [u8; $typename::BYTES_PER_SAMPLE]>>
+        impl<'a, T> ConvertBytes<T, $typename, &'a dyn Adapter<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
                 T: FloatCore + ToPrimitive + 'a,
             {
@@ -86,7 +86,7 @@ macro_rules! byte_convert_traits_newtype {
                     stringify!($typename), "`]."
                 )]
                 pub fn new(
-                    buf: &'a dyn Adapter<'a, [u8; $typename::BYTES_PER_SAMPLE]>,
+                    buf: &'a dyn Adapter<[u8; $typename::BYTES_PER_SAMPLE]>,
                 ) -> Self {
                     Self {
                         _phantom: core::marker::PhantomData,
@@ -96,7 +96,7 @@ macro_rules! byte_convert_traits_newtype {
                 }
             }
 
-            impl<'a, T> ConvertBytes<T, $typename, &'a mut dyn AdapterMut<'a, [u8; $typename::BYTES_PER_SAMPLE]>>
+            impl<'a, T> ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
                 T: FloatCore + ToPrimitive + 'a,
             {
@@ -106,7 +106,7 @@ macro_rules! byte_convert_traits_newtype {
                     stringify!($typename), "`]."
                 )]
                 pub fn new_mut(
-                    buf: &'a mut dyn AdapterMut<'a, [u8; $typename::BYTES_PER_SAMPLE]>,
+                    buf: &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>,
                 ) -> Self {
                     Self {
                         _phantom: core::marker::PhantomData,
@@ -116,7 +116,7 @@ macro_rules! byte_convert_traits_newtype {
                 }
             }
 
-            unsafe impl<'a, T> Adapter<'a, T> for ConvertBytes<T, $typename, &'a dyn Adapter<'a, [u8; $typename::BYTES_PER_SAMPLE]>>
+            unsafe impl<'a, T> Adapter<T> for ConvertBytes<T, $typename, &'a dyn Adapter<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
             T: FloatCore + ToPrimitive + 'a,
             {
@@ -129,7 +129,7 @@ macro_rules! byte_convert_traits_newtype {
                 implement_wrapped_size_getters!();
             }
 
-            unsafe impl<'a, T> Adapter<'a, T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<'a, [u8; $typename::BYTES_PER_SAMPLE]>>
+            unsafe impl<'a, T> Adapter<T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
             T: FloatCore + ToPrimitive + 'a,
             {
@@ -142,7 +142,7 @@ macro_rules! byte_convert_traits_newtype {
                 implement_wrapped_size_getters!();
             }
 
-            unsafe impl<'a, T> AdapterMut<'a, T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<'a, [u8; $typename::BYTES_PER_SAMPLE]>>
+            unsafe impl<'a, T> AdapterMut<T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
             T: FloatCore + ToPrimitive + 'a,
             {
@@ -222,14 +222,14 @@ pub struct ConvertNumbers<U, V> {
     buf: U,
 }
 
-impl<'a, T, U> ConvertNumbers<&'a dyn Adapter<'a, U>, T>
+impl<'a, T, U> ConvertNumbers<&'a dyn Adapter<U>, T>
 where
     T: FloatCore + ToPrimitive + 'a,
     U: RawSample + 'a,
 {
     /// Create a new wrapper for a buffer implementing the [Adapter] trait,
     /// containing numerical samples.
-    pub fn new(buf: &'a dyn Adapter<'a, U>) -> Self {
+    pub fn new(buf: &'a dyn Adapter<U>) -> Self {
         Self {
             _phantom: core::marker::PhantomData,
             buf,
@@ -237,14 +237,14 @@ where
     }
 }
 
-impl<'a, T, U> ConvertNumbers<&'a mut dyn AdapterMut<'a, U>, T>
+impl<'a, T, U> ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
 where
     T: FloatCore + ToPrimitive + 'a,
     U: RawSample + 'a,
 {
     /// Create a new wrapper for a mutable buffer implementing the [AdapterMut] trait,
     /// containing numerical samples.
-    pub fn new_mut(buf: &'a mut dyn AdapterMut<'a, U>) -> Self {
+    pub fn new_mut(buf: &'a mut dyn AdapterMut<U>) -> Self {
         Self {
             _phantom: core::marker::PhantomData,
             buf,
@@ -252,7 +252,7 @@ where
     }
 }
 
-unsafe impl<'a, T, U> Adapter<'a, T> for ConvertNumbers<&'a dyn Adapter<'a, U>, T>
+unsafe impl<'a, T, U> Adapter<T> for ConvertNumbers<&'a dyn Adapter<U>, T>
 where
     T: FloatCore + ToPrimitive + 'a,
     U: RawSample + 'a,
@@ -268,7 +268,7 @@ where
     implement_wrapped_size_getters!();
 }
 
-unsafe impl<'a, T, U> Adapter<'a, T> for ConvertNumbers<&'a mut dyn AdapterMut<'a, U>, T>
+unsafe impl<'a, T, U> Adapter<T> for ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
 where
     T: FloatCore + ToPrimitive + 'a,
     U: RawSample + 'a,
@@ -284,7 +284,7 @@ where
     implement_wrapped_size_getters!();
 }
 
-unsafe impl<'a, T, U> AdapterMut<'a, T> for ConvertNumbers<&'a mut dyn AdapterMut<'a, U>, T>
+unsafe impl<'a, T, U> AdapterMut<T> for ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
 where
     T: FloatCore + ToPrimitive + 'a,
     U: RawSample + Clone + 'a,

--- a/audioadapter-buffers/src/direct.rs
+++ b/audioadapter-buffers/src/direct.rs
@@ -160,7 +160,7 @@ impl<'a, T> SequentialSliceOfVecs<&'a mut [Vec<T>]> {
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSliceOfVecs<&'a [Vec<T>]>
+unsafe impl<T> Adapter<T> for SequentialSliceOfVecs<&[Vec<T>]>
 where
     T: Clone,
 {
@@ -185,7 +185,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSliceOfVecs<&'a mut [Vec<T>]>
+unsafe impl<T> Adapter<T> for SequentialSliceOfVecs<&mut [Vec<T>]>
 where
     T: Clone,
 {
@@ -210,7 +210,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> AdapterMut<'a, T> for SequentialSliceOfVecs<&'a mut [Vec<T>]>
+unsafe impl<T> AdapterMut<T> for SequentialSliceOfVecs<&mut [Vec<T>]>
 where
     T: Clone,
 {
@@ -361,7 +361,7 @@ impl<'a, T> SparseSequentialSliceOfVecs<'a, &'a mut [Vec<T>]> {
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for SparseSequentialSliceOfVecs<'a, &'a [Vec<T>]>
+unsafe impl<'a, T> Adapter<T> for SparseSequentialSliceOfVecs<'a, &'a [Vec<T>]>
 where
     T: Clone + Default,
 {
@@ -389,7 +389,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for SparseSequentialSliceOfVecs<'a, &'a mut [Vec<T>]>
+unsafe impl<'a, T> Adapter<T> for SparseSequentialSliceOfVecs<'a, &'a mut [Vec<T>]>
 where
     T: Clone + Default,
 {
@@ -417,7 +417,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> AdapterMut<'a, T> for SparseSequentialSliceOfVecs<'a, &'a mut [Vec<T>]>
+unsafe impl<'a, T> AdapterMut<T> for SparseSequentialSliceOfVecs<'a, &'a mut [Vec<T>]>
 where
     T: Clone + Default,
 {
@@ -555,7 +555,7 @@ impl<'a, T> SequentialSliceOfSlices<&'a mut [&'a mut [T]]> {
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSliceOfSlices<&'a [&'a [T]]>
+unsafe impl<'a, T> Adapter<T> for SequentialSliceOfSlices<&'a [&'a [T]]>
 where
     T: Clone,
 {
@@ -579,7 +579,7 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSliceOfSlices<&'a mut [&'a mut [T]]>
+unsafe impl<'a, T> Adapter<T> for SequentialSliceOfSlices<&'a mut [&'a mut [T]]>
 where
     T: Clone,
 {
@@ -603,7 +603,7 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for SequentialSliceOfSlices<&'a mut [&'a mut [T]]>
+unsafe impl<'a, T> AdapterMut<T> for SequentialSliceOfSlices<&'a mut [&'a mut [T]]>
 where
     T: Clone,
 {
@@ -750,7 +750,7 @@ impl<'a, T> SparseSequentialSliceOfSlices<'a, &'a mut [&'a mut [T]]> {
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SparseSequentialSliceOfSlices<'a, &'a [&'a [T]]>
+unsafe impl<'a, T> Adapter<T> for SparseSequentialSliceOfSlices<'a, &'a [&'a [T]]>
 where
     T: Clone + Default,
 {
@@ -777,7 +777,7 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SparseSequentialSliceOfSlices<'a, &'a mut [&'a mut [T]]>
+unsafe impl<'a, T> Adapter<T> for SparseSequentialSliceOfSlices<'a, &'a mut [&'a mut [T]]>
 where
     T: Clone + Default,
 {
@@ -804,7 +804,7 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for SparseSequentialSliceOfSlices<'a, &'a mut [&'a mut [T]]>
+unsafe impl<'a, T> AdapterMut<T> for SparseSequentialSliceOfSlices<'a, &'a mut [&'a mut [T]]>
 where
     T: Clone + Default,
 {
@@ -946,7 +946,7 @@ impl<'a, T> InterleavedSliceOfVecs<&'a mut [Vec<T>]> {
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for InterleavedSliceOfVecs<&'a [Vec<T>]>
+unsafe impl<T> Adapter<T> for InterleavedSliceOfVecs<&[Vec<T>]>
 where
     T: Clone,
 {
@@ -972,7 +972,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for InterleavedSliceOfVecs<&'a mut [Vec<T>]>
+unsafe impl<T> Adapter<T> for InterleavedSliceOfVecs<&mut [Vec<T>]>
 where
     T: Clone,
 {
@@ -998,7 +998,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> AdapterMut<'a, T> for InterleavedSliceOfVecs<&'a mut [Vec<T>]>
+unsafe impl<T> AdapterMut<T> for InterleavedSliceOfVecs<&mut [Vec<T>]>
 where
     T: Clone,
 {
@@ -1120,7 +1120,7 @@ impl<'a, T> InterleavedSlice<&'a mut [T]> {
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for InterleavedSlice<&'a [T]>
+unsafe impl<T> Adapter<T> for InterleavedSlice<&[T]>
 where
     T: Clone,
 {
@@ -1147,7 +1147,7 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for InterleavedSlice<&'a mut [T]>
+unsafe impl<T> Adapter<T> for InterleavedSlice<&mut [T]>
 where
     T: Clone,
 {
@@ -1174,7 +1174,7 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for InterleavedSlice<&'a mut [T]>
+unsafe impl<T> AdapterMut<T> for InterleavedSlice<&mut [T]>
 where
     T: Clone,
 {
@@ -1316,7 +1316,7 @@ impl<'a, T> SequentialSlice<&'a mut [T]> {
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSlice<&'a [T]>
+unsafe impl<T> Adapter<T> for SequentialSlice<&[T]>
 where
     T: Clone,
 {
@@ -1344,7 +1344,7 @@ where
 }
 
 // Implement also for mutable version, identical to the immutable impl.
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSlice<&'a mut [T]>
+unsafe impl<T> Adapter<T> for SequentialSlice<&mut [T]>
 where
     T: Clone,
 {
@@ -1371,7 +1371,7 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for SequentialSlice<&'a mut [T]>
+unsafe impl<T> AdapterMut<T> for SequentialSlice<&mut [T]>
 where
     T: Clone,
 {

--- a/audioadapter-buffers/src/dummy.rs
+++ b/audioadapter-buffers/src/dummy.rs
@@ -28,9 +28,9 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for Dummy<T>
+unsafe impl<T> Adapter<T> for Dummy<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn read_sample_unchecked(&self, _channel: usize, _frame: usize) -> T {
         self.default.clone()
@@ -39,9 +39,9 @@ where
     implement_size_getters!();
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for Dummy<T>
+unsafe impl<T> AdapterMut<T> for Dummy<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn write_sample_unchecked(
         &mut self,

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -399,7 +399,7 @@ where
 
 macro_rules! impl_traits_newtype {
     ($structname:ident) => {
-        unsafe impl<'a, T, U> Adapter<'a, T> for $structname<&'a [U], T>
+        unsafe impl<'a, T, U> Adapter<T> for $structname<&'a [U], T>
         where
             T: FloatCore + ToPrimitive + 'a,
             U: RawSample,
@@ -412,7 +412,7 @@ macro_rules! impl_traits_newtype {
             implement_size_getters!();
         }
 
-        unsafe impl<'a, T, U> Adapter<'a, T> for $structname<&'a mut [U], T>
+        unsafe impl<'a, T, U> Adapter<T> for $structname<&'a mut [U], T>
         where
             T: FloatCore + ToPrimitive + 'a,
             U: RawSample,
@@ -425,7 +425,7 @@ macro_rules! impl_traits_newtype {
             implement_size_getters!();
         }
 
-        unsafe impl<'a, T, U> AdapterMut<'a, T> for $structname<&'a mut [U], T>
+        unsafe impl<'a, T, U> AdapterMut<T> for $structname<&'a mut [U], T>
         where
             T: FloatCore + ToPrimitive + 'a,
             U: RawSample + Clone,

--- a/audioadapter-buffers/src/owned.rs
+++ b/audioadapter-buffers/src/owned.rs
@@ -102,9 +102,9 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for InterleavedOwned<T>
+unsafe impl<T> Adapter<T> for InterleavedOwned<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
         let index = self.calc_index(channel, frame);
@@ -129,9 +129,9 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for InterleavedOwned<T>
+unsafe impl<T> AdapterMut<T> for InterleavedOwned<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &T) -> bool {
         let index = self.calc_index(channel, frame);
@@ -277,9 +277,9 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SequentialOwned<T>
+unsafe impl<T> Adapter<T> for SequentialOwned<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
         let index = self.calc_index(channel, frame);
@@ -304,9 +304,9 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for SequentialOwned<T>
+unsafe impl<T> AdapterMut<T> for SequentialOwned<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &T) -> bool {
         let index = self.calc_index(channel, frame);

--- a/audioadapter/Cargo.toml
+++ b/audioadapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]

--- a/audioadapter/examples/custom_adapter.rs
+++ b/audioadapter/examples/custom_adapter.rs
@@ -10,15 +10,15 @@ use audioadapter::Adapter;
 use num_traits::Zero;
 use std::str::FromStr;
 
-struct MyStruct<'a, T> {
-    _phantom: core::marker::PhantomData<&'a T>,
+struct MyStruct<T> {
+    _phantom: core::marker::PhantomData<T>,
     data: Vec<String>,
     channels: usize,
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for MyStruct<'a, T>
+unsafe impl<T> Adapter<T> for MyStruct<T>
 where
-    T: Clone + FromStr + Zero + 'a,
+    T: Clone + FromStr + Zero,
 {
     fn channels(&self) -> usize {
         self.channels
@@ -43,7 +43,7 @@ fn main() {
         "5".to_owned(),
         "6".to_owned(),
     ];
-    let adapter: MyStruct<'_, f32> = MyStruct {
+    let adapter: MyStruct<f32> = MyStruct {
         _phantom: core::marker::PhantomData,
         data,
         channels: 2,

--- a/audioadapter/src/audio.rs
+++ b/audioadapter/src/audio.rs
@@ -7,9 +7,9 @@ use crate::{Adapter, AdapterMut};
 
 use audio_core::{Buf, BufMut, Channel, ChannelMut, ExactSizeBuf, Sample};
 
-unsafe impl<'a, T, U> Adapter<'a, T> for U
+unsafe impl<T, U> Adapter<T> for U
 where
-    T: Clone + Sample + 'a,
+    T: Clone + Sample,
     U: Buf<Sample = T> + ExactSizeBuf<Sample = T>,
 {
     fn channels(&self) -> usize {
@@ -43,9 +43,9 @@ where
     }
 }
 
-unsafe impl<'a, T, U> AdapterMut<'a, T> for U
+unsafe impl<T, U> AdapterMut<T> for U
 where
-    T: Clone + Sample + 'a,
+    T: Clone + Sample,
     U: BufMut<Sample = T> + ExactSizeBuf<Sample = T>,
 {
     unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &T) -> bool {

--- a/audioadapter/src/iterators.rs
+++ b/audioadapter/src/iterators.rs
@@ -4,64 +4,61 @@ use crate::Adapter;
 
 /// A trait providing convenient iteration through frames and/or channels
 /// of an [Adapter].
-pub trait AdapterIterators<'a, T: 'a> {
+pub trait AdapterIterators<T> {
     /// Get an iterator that yields the sample value of the specified channel.
-    fn iter_channel(&self, channel: usize) -> Option<ChannelSamples<'a, '_, T>>;
+    fn iter_channel(&self, channel: usize) -> Option<ChannelSamples<'_, T>>;
 
     /// Get an iterator that yields iterators for the channels.
-    fn iter_channels(&self) -> Channels<'a, '_, T>;
+    fn iter_channels(&self) -> Channels<'_, T>;
 
     /// Get an iterator that yields the sample values of the specified frame.
-    fn iter_frame(&self, frame: usize) -> Option<FrameSamples<'a, '_, T>>;
+    fn iter_frame(&self, frame: usize) -> Option<FrameSamples<'_, T>>;
 
     /// Get an iterator that yields iterators for the frames.
-    fn iter_frames(&self) -> Frames<'a, '_, T>;
+    fn iter_frames(&self) -> Frames<'_, T>;
 }
 
-impl<'a, T, U> AdapterIterators<'a, T> for U
+impl<T, U> AdapterIterators<T> for U
 where
-    T: Clone + 'a,
-    U: Adapter<'a, T>,
+    T: Clone,
+    U: Adapter<T>,
 {
-    fn iter_channel(&self, channel: usize) -> Option<ChannelSamples<'a, '_, T>> {
+    fn iter_channel(&self, channel: usize) -> Option<ChannelSamples<'_, T>> {
         ChannelSamples::new(self, channel)
     }
 
-    fn iter_channels(&self) -> Channels<'a, '_, T> {
+    fn iter_channels(&self) -> Channels<'_, T> {
         Channels::new(self)
     }
 
-    fn iter_frame(&self, frame: usize) -> Option<FrameSamples<'a, '_, T>> {
+    fn iter_frame(&self, frame: usize) -> Option<FrameSamples<'_, T>> {
         FrameSamples::new(self, frame)
     }
 
-    fn iter_frames(&self) -> Frames<'a, '_, T> {
+    fn iter_frames(&self) -> Frames<'_, T> {
         Frames::new(self)
     }
 }
 
 /// An iterator that yields the sample values of a channel.
-pub struct ChannelSamples<'a, 'b, T> {
-    buf: &'b dyn Adapter<'a, T>,
+pub struct ChannelSamples<'b, T> {
+    buf: &'b dyn Adapter<T>,
     frame: usize,
     nbr_frames: usize,
     channel: usize,
 }
 
-impl<'a, 'b, T> ChannelSamples<'a, 'b, T>
+impl<'b, T> ChannelSamples<'b, T>
 where
     T: Clone,
 {
-    pub fn new(
-        buffer: &'b dyn Adapter<'a, T>,
-        channel: usize,
-    ) -> Option<ChannelSamples<'a, 'b, T>> {
+    pub fn new(buffer: &'b dyn Adapter<T>, channel: usize) -> Option<ChannelSamples<'b, T>> {
         if channel >= buffer.channels() {
             return None;
         }
         let nbr_frames = buffer.frames();
         Some(ChannelSamples {
-            buf: buffer as &'b dyn Adapter<'a, T>,
+            buf: buffer as &'b dyn Adapter<T>,
             frame: 0,
             nbr_frames,
             channel,
@@ -69,7 +66,7 @@ where
     }
 }
 
-impl<T> Iterator for ChannelSamples<'_, '_, T>
+impl<T> Iterator for ChannelSamples<'_, T>
 where
     T: Clone,
 {
@@ -86,24 +83,24 @@ where
 }
 
 /// An iterator that yields the samples values of a frame.
-pub struct FrameSamples<'a, 'b, T> {
-    buf: &'b dyn Adapter<'a, T>,
+pub struct FrameSamples<'b, T> {
+    buf: &'b dyn Adapter<T>,
     frame: usize,
     nbr_channels: usize,
     channel: usize,
 }
 
-impl<'a, 'b, T> FrameSamples<'a, 'b, T>
+impl<'b, T> FrameSamples<'b, T>
 where
     T: Clone,
 {
-    pub fn new(buffer: &'b dyn Adapter<'a, T>, frame: usize) -> Option<FrameSamples<'a, 'b, T>> {
+    pub fn new(buffer: &'b dyn Adapter<T>, frame: usize) -> Option<FrameSamples<'b, T>> {
         if frame >= buffer.frames() {
             return None;
         }
         let nbr_channels = buffer.channels();
         Some(FrameSamples {
-            buf: buffer as &'b dyn Adapter<'a, T>,
+            buf: buffer as &'b dyn Adapter<T>,
             channel: 0,
             nbr_channels,
             frame,
@@ -111,7 +108,7 @@ where
     }
 }
 
-impl<T> Iterator for FrameSamples<'_, '_, T>
+impl<T> Iterator for FrameSamples<'_, T>
 where
     T: Clone,
 {
@@ -130,31 +127,31 @@ where
 // -------------------- Iterators returning immutable iterators --------------------
 
 /// An iterator that yields a [ChannelSamples] iterator for each channel of an [Adapter].
-pub struct Channels<'a, 'b, T> {
-    buf: &'b dyn Adapter<'a, T>,
+pub struct Channels<'b, T> {
+    buf: &'b dyn Adapter<T>,
     nbr_channels: usize,
     channel: usize,
 }
 
-impl<'a, 'b, T> Channels<'a, 'b, T>
+impl<'b, T> Channels<'b, T>
 where
     T: Clone,
 {
-    pub fn new(buffer: &'b dyn Adapter<'a, T>) -> Channels<'a, 'b, T> {
+    pub fn new(buffer: &'b dyn Adapter<T>) -> Channels<'b, T> {
         let nbr_channels = buffer.channels();
         Channels {
-            buf: buffer as &'b dyn Adapter<'a, T>,
+            buf: buffer as &'b dyn Adapter<T>,
             channel: 0,
             nbr_channels,
         }
     }
 }
 
-impl<'a, 'b, T> Iterator for Channels<'a, 'b, T>
+impl<'b, T> Iterator for Channels<'b, T>
 where
     T: Clone,
 {
-    type Item = ChannelSamples<'a, 'b, T>;
+    type Item = ChannelSamples<'b, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.channel >= self.nbr_channels {
@@ -167,31 +164,31 @@ where
 }
 
 /// An iterator that yields a [FrameSamples] iterator for each frame of an [Adapter].
-pub struct Frames<'a, 'b, T> {
-    buf: &'b dyn Adapter<'a, T>,
+pub struct Frames<'b, T> {
+    buf: &'b dyn Adapter<T>,
     nbr_frames: usize,
     frame: usize,
 }
 
-impl<'a, 'b, T> Frames<'a, 'b, T>
+impl<'b, T> Frames<'b, T>
 where
     T: Clone,
 {
-    pub fn new(buffer: &'b dyn Adapter<'a, T>) -> Frames<'a, 'b, T> {
+    pub fn new(buffer: &'b dyn Adapter<T>) -> Frames<'b, T> {
         let nbr_frames = buffer.frames();
         Frames {
-            buf: buffer as &'b dyn Adapter<'a, T>,
+            buf: buffer as &'b dyn Adapter<T>,
             frame: 0,
             nbr_frames,
         }
     }
 }
 
-impl<'a, 'b, T> Iterator for Frames<'a, 'b, T>
+impl<'b, T> Iterator for Frames<'b, T>
 where
     T: Clone,
 {
-    type Item = FrameSamples<'a, 'b, T>;
+    type Item = FrameSamples<'b, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.frame >= self.nbr_frames {

--- a/audioadapter/src/lib.rs
+++ b/audioadapter/src/lib.rs
@@ -46,9 +46,9 @@ pub mod tests {
         }
     }
 
-    unsafe impl<'a, T> Adapter<'a, T> for MinimalAdapter<T>
+    unsafe impl<T> Adapter<T> for MinimalAdapter<T>
     where
-        T: Clone + 'a,
+        T: Clone,
     {
         unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
             let index = frame * self.channels + channel;
@@ -64,9 +64,9 @@ pub mod tests {
         }
     }
 
-    unsafe impl<'a, T> AdapterMut<'a, T> for MinimalAdapter<T>
+    unsafe impl<T> AdapterMut<T> for MinimalAdapter<T>
     where
-        T: Clone + 'a,
+        T: Clone,
     {
         unsafe fn write_sample_unchecked(
             &mut self,
@@ -87,9 +87,9 @@ pub mod tests {
     /// It takes a mutable reference to an adapter and runs a series of tests.
     /// The adapter is expected to have at least 2 channels and 4 frames.
     /// The sample type `T` must support `Default`, `Clone`, `PartialEq`, `Debug`, and be convertible to and from `usize`.
-    pub fn test_adapter_mut_methods<'a, T>(buffer: &mut dyn AdapterMut<'a, T>)
+    pub fn test_adapter_mut_methods<T>(buffer: &mut dyn AdapterMut<T>)
     where
-        T: Default + Clone + PartialEq + core::fmt::Debug + From<usize> + Into<usize> + 'a,
+        T: Default + Clone + PartialEq + core::fmt::Debug + From<usize> + Into<usize>,
     {
         // Ensure buffer is large enough for tests
         assert!(
@@ -200,9 +200,9 @@ pub mod tests {
     /// It takes a mutable reference to an adapter and runs a series of tests.
     /// The adapter is expected to have at least 2 channels and 4 frames.
     /// The sample type `T` must be a floating-point type implementing `FloatCore`, `NumCast`, `Default`, `Clone`, `PartialEq`, and `Debug`.
-    pub fn test_float_adapter_mut_methods<'a, T>(buffer: &mut dyn AdapterMut<'a, T>)
+    pub fn test_float_adapter_mut_methods<T>(buffer: &mut dyn AdapterMut<T>)
     where
-        T: FloatCore + NumCast + Default + Clone + PartialEq + core::fmt::Debug + 'a,
+        T: FloatCore + NumCast + Default + Clone + PartialEq + core::fmt::Debug,
     {
         // Helper for approximate float comparison
         let assert_approx_eq = |a: T, b: T, message: &str| {

--- a/audioadapter/src/stats.rs
+++ b/audioadapter/src/stats.rs
@@ -45,9 +45,9 @@ fn sqrt_newton(value: f64) -> f64 {
 /// This requires that the samples are of a numerical type, that implement the
 /// [num_traits::ToPrimitive], [num_traits::Num] and [core::cmp::PartialOrd] traits.
 /// This includes all the built in numerical types such as `i16`, `i32`, `f32` etc.
-pub trait AdapterStats<'a, T>: Adapter<'a, T>
+pub trait AdapterStats<T>: Adapter<T>
 where
-    T: Clone + ToPrimitive + Num + PartialOrd + 'a,
+    T: Clone + ToPrimitive + Num + PartialOrd,
 {
     /// Calculate the RMS value of the given channel.
     /// The result is returned as `f64`.
@@ -140,10 +140,10 @@ where
     }
 }
 
-impl<'a, T, U> AdapterStats<'a, T> for U
+impl<T, U> AdapterStats<T> for U
 where
-    T: Clone + ToPrimitive + Num + PartialOrd + 'a,
-    U: Adapter<'a, T>,
+    T: Clone + ToPrimitive + Num + PartialOrd,
+    U: Adapter<T>,
 {
 }
 

--- a/audioadapter/src/traits.rs
+++ b/audioadapter/src/traits.rs
@@ -22,7 +22,7 @@
 /// use these bounds before calling `read_sample_unchecked` internally.
 /// If the reported bounds are wrong, those internal unchecked accesses can become
 /// out of bounds and cause undefined behavior.
-pub unsafe trait Adapter<'a, T: 'a> {
+pub unsafe trait Adapter<T> {
     /// Read the sample at
     /// a given combination of frame and channel.
     ///
@@ -118,9 +118,9 @@ pub unsafe trait Adapter<'a, T: 'a> {
 /// use these bounds before calling `write_sample_unchecked` internally.
 /// If the reported bounds are wrong, those internal unchecked accesses can become
 /// out of bounds and cause undefined behavior.
-pub unsafe trait AdapterMut<'a, T>: Adapter<'a, T>
+pub unsafe trait AdapterMut<T>: Adapter<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     /// Write a sample to the
     /// given combination of frame and channel.
@@ -236,7 +236,7 @@ where
     /// no values will be copied and `None` is returned.
     fn copy_from_other_to_channel(
         &mut self,
-        other: &dyn Adapter<'a, T>,
+        other: &dyn Adapter<T>,
         other_channel: usize,
         self_channel: usize,
         other_skip: usize,


### PR DESCRIPTION
## Summary

Drops the lifetime parameter from the core traits: `Adapter<'a, T: 'a>` becomes `Adapter<T>`, and `AdapterMut<'a, T> where T: Clone + 'a` becomes `AdapterMut<T> where T: Clone`. Users now write `Adapter<i16>` / `&dyn Adapter<i16>` instead of the lifetime-carrying forms.

The lifetime was genuinely needed at the start, when reads returned references into the buffer (`get(&self) -> Option<&T>`). Once reads became value-returning (`read_sample(&self) -> T`, driven by on-the-fly conversion), nothing borrowed the buffer through the trait anymore and `'a` became dead weight, carried along through the `AudioBuffer` → `Adapter` rename and the crate split.

### Why it's safe
- `'a` never appears in a method return type. It only showed up in the trait headers and in one argument (`copy_from_other_to_channel`'s `other`).
- The only capability it enabled was a reference-typed sample (`T = &'a U`); a sweep of both crates shows every `T` is owned, so nothing depended on it.
- Confirmed empirically: no impl needed `T: 'a` for variance or dropck. It was pure find-and-replace.

## Changes

**Core (`audioadapter`)**
- `traits.rs`: trait headers and the `other: &dyn Adapter<T>` argument.
- `iterators.rs`: collapsed the doubled `<'a, 'b, T>` to `<'b, T>` on all four iterators and `AdapterIterators`.
- `audio.rs`, `stats.rs`, `lib.rs`: dropped `'a` from the blanket impls, `MinimalAdapter` impls, the stats trait, and the test helpers.
- `examples/custom_adapter.rs`: removed the now-pointless phantom lifetime.

**Buffers (`audioadapter-buffers`)**
- `direct.rs`, `owned.rs`, `dummy.rs`, `number_to_float.rs`, `adapter_to_float.rs`: collapsed trait-position `Adapter<'a, T>` → `Adapter<T>`. The `'a` on impls for borrowed buffers (slices, slice-of-slices, sparse types) stays; clippy elided the cases where it became single-use.

**Versioning**
- `audioadapter` 3.0.1 → 4.0.0 (breaking trait change); buffers' dependency requirement bumped to 4.0. All three crates now ship at 4.0.0.

## Verification
- `cargo build --workspace --all-features`: clean
- `cargo test --workspace --all-features`: 185 tests pass
- `cargo clippy --workspace --all-targets --all-features`: 0 warnings
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`: clean