### PR TITLE
Release 4.0: byte-slice soundness, lifetime removal, overflow hardening, copy helpers

### DIFF
--- a/audioadapter-buffers/Cargo.toml
+++ b/audioadapter-buffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter-buffers"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]

--- a/audioadapter-buffers/Cargo.toml
+++ b/audioadapter-buffers/Cargo.toml
@@ -18,13 +18,13 @@ alloc = []
 
 [dependencies]
 num-traits.workspace = true
-audioadapter = { version = "3.0.0", path = "../audioadapter" }
+audioadapter = { version = "4.0.0", path = "../audioadapter" }
 audioadapter-sample = { version = "4.0.0", path = "../audioadapter-sample", default-features = false, features = ["audio"] }
 
 
 [dev-dependencies]
 criterion = "0.6"
-audioadapter = { version = "3.0.0", path = "../audioadapter", features = ["test-utils"]}
+audioadapter = { version = "4.0.0", path = "../audioadapter", features = ["test-utils"]}
 
 [[bench]]
 name = "iteration"

--- a/audioadapter-buffers/Cargo.toml
+++ b/audioadapter-buffers/Cargo.toml
@@ -19,7 +19,7 @@ alloc = []
 [dependencies]
 num-traits.workspace = true
 audioadapter = { version = "3.0.0", path = "../audioadapter" }
-audioadapter-sample = { version = "3.0.0", path = "../audioadapter-sample", default-features = false, features = ["audio"] }
+audioadapter-sample = { version = "4.0.0", path = "../audioadapter-sample", default-features = false, features = ["audio"] }
 
 
 [dev-dependencies]

--- a/audioadapter-buffers/README.md
+++ b/audioadapter-buffers/README.md
@@ -88,6 +88,62 @@ stored as 3 bytes in little-endian order without padding.
 24-bit samples are also commonly stored with a padding byte, so that each sample takes up four bytes.
 This is handled by selecting `I24_4RJ_LE` or `I24_4LJ_LE` as the format.
 
+The sample format types such as `I24_LE` are re-exported from `audioadapter-sample`,
+so you can also reach them as `audioadapter_buffers::sample::I24_LE`
+without adding a separate dependency.
+
+### Example, write float values into a byte buffer
+The mutable constructors let you go the other way and write `f32` values
+into a buffer of raw bytes, converting on the fly.
+This writes interleaved 16-bit little-endian samples:
+
+```rust
+use audioadapter_buffers::number_to_float::InterleavedNumbers;
+use audioadapter_buffers::sample::I16_LE;
+use audioadapter::{Adapter, AdapterMut};
+
+// space for 2 channels * 3 frames * 2 bytes per sample => 12 bytes
+let mut data: Vec<u8> = vec![0; 12];
+
+// wrap the byte buffer for mutable access
+let mut buffer =
+    InterleavedNumbers::<&mut [I16_LE], f32>::new_from_bytes_mut(&mut data, 2, 3).unwrap();
+
+// write a value to every sample
+for channel in 0..buffer.channels() {
+    for frame in 0..buffer.frames() {
+        buffer.write_sample(channel, frame, &0.5).unwrap();
+    }
+}
+```
+
+## Wrapping existing buffers
+The [adapter_to_float] module wraps a buffer that already implements the
+`audioadapter` traits, adding on-the-fly conversion to and from float.
+Use `ConvertNumbers` for buffers of numeric samples,
+and `ConvertBytes` for buffers of raw byte arrays.
+
+### Example, read an existing i16 buffer as floats
+```rust
+use audioadapter::Adapter;
+use audioadapter_buffers::adapter_to_float::ConvertNumbers;
+use audioadapter_buffers::direct::InterleavedSlice;
+
+// Make a vector with some dummy data and wrap it as an interleaved i16 buffer.
+let data: Vec<i16> = vec![1, 2, 3, 4, 5, 6];
+let int_buffer = InterleavedSlice::new(&data, 2, 3).unwrap();
+
+// Wrap the buffer again with a converter to read the values as floats.
+let converter = ConvertNumbers::<_, f32>::new(&int_buffer as &dyn Adapter<i16>);
+
+for channel in 0..converter.channels() {
+    for frame in 0..converter.frames() {
+        let value = converter.read_sample(channel, frame).unwrap();
+        println!("Channel: {}, frame: {}, value: {}", channel, frame, value);
+    }
+}
+```
+
 ## Use without the standard library
 This crate can be used in `no_std` environments if the `std` Cargo feature is disabled.
 You can also enable the `alloc` feature to get the buffer types in the [owned] module.

--- a/audioadapter-buffers/src/adapter_to_float.rs
+++ b/audioadapter-buffers/src/adapter_to_float.rs
@@ -55,6 +55,15 @@ macro_rules! implement_wrapped_size_getters {
 /// A wrapper for an [Adapter] or [AdapterMut] buffer containing samples
 /// stored as byte arrays.
 /// The wrapper enables reading and writing the samples as floats.
+///
+/// # Type parameters
+/// - `T`: the floating point type that samples are converted to and from when
+///   reading and writing, for example `f32` or `f64`.
+/// - `U`: the byte-wrapper sample format type, for example [`I16_LE`] or
+///   [`F32_LE`]. It implements [BytesSample] and [RawSample], and determines the
+///   sample size as `[u8; U::BYTES_PER_SAMPLE]`.
+/// - `V`: the wrapped buffer type, an [Adapter] or [AdapterMut] over byte arrays
+///   of length `U::BYTES_PER_SAMPLE`.
 pub struct ConvertBytes<T, U, V>
 where
     T: FloatCore + ToPrimitive,
@@ -71,8 +80,11 @@ macro_rules! byte_convert_traits_newtype {
             where
                 T: FloatCore + ToPrimitive + 'a,
             {
-                #[doc = "Create a new wrapper for an [Adapter] buffer of byte arrays, `[u8;  U::BYTES_PER_SAMPLE ]`,"]
-                #[doc = "containing samples of type ` $typename `."]
+                #[doc = concat!(
+                    "Create a new wrapper for an [Adapter] buffer of byte arrays, `[u8; ",
+                    stringify!($typename), "::BYTES_PER_SAMPLE]`, containing samples of type [`",
+                    stringify!($typename), "`]."
+                )]
                 pub fn new(
                     buf: &'a dyn Adapter<'a, [u8; $typename::BYTES_PER_SAMPLE]>,
                 ) -> Self {
@@ -88,8 +100,11 @@ macro_rules! byte_convert_traits_newtype {
             where
                 T: FloatCore + ToPrimitive + 'a,
             {
-                #[doc = "Create a new wrapper for an mutable [AdapterMut] buffer of byte arrays, `[u8;  $bytes ]`,"]
-                #[doc = "containing samples of type ` $typename `."]
+                #[doc = concat!(
+                    "Create a new wrapper for a mutable [AdapterMut] buffer of byte arrays, `[u8; ",
+                    stringify!($typename), "::BYTES_PER_SAMPLE]`, containing samples of type [`",
+                    stringify!($typename), "`]."
+                )]
                 pub fn new_mut(
                     buf: &'a mut dyn AdapterMut<'a, [u8; $typename::BYTES_PER_SAMPLE]>,
                 ) -> Self {
@@ -195,6 +210,13 @@ byte_convert_traits_newtype!(F64_BE);
 /// A wrapper for an [Adapter] or [AdapterMut] buffer containing samples
 /// stored as numeric types.
 /// The wrapper enables reading and writing the samples as floats.
+///
+/// # Type parameters
+/// - `U`: the wrapped buffer type, an [Adapter] or [AdapterMut] over a numeric
+///   sample type, for example `&dyn Adapter<i16>`. The sample type implements
+///   [RawSample].
+/// - `V`: the floating point type that samples are converted to and from when
+///   reading and writing, for example `f32` or `f64`.
 pub struct ConvertNumbers<U, V> {
     _phantom: core::marker::PhantomData<V>,
     buf: U,

--- a/audioadapter-buffers/src/adapter_to_float.rs
+++ b/audioadapter-buffers/src/adapter_to_float.rs
@@ -78,7 +78,7 @@ macro_rules! byte_convert_traits_newtype {
     ($typename:ident) => {
         impl<'a, T> ConvertBytes<T, $typename, &'a dyn Adapter<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
-                T: FloatCore + ToPrimitive + 'a,
+                T: FloatCore + ToPrimitive,
             {
                 #[doc = concat!(
                     "Create a new wrapper for an [Adapter] buffer of byte arrays, `[u8; ",
@@ -98,7 +98,7 @@ macro_rules! byte_convert_traits_newtype {
 
             impl<'a, T> ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
-                T: FloatCore + ToPrimitive + 'a,
+                T: FloatCore + ToPrimitive,
             {
                 #[doc = concat!(
                     "Create a new wrapper for a mutable [AdapterMut] buffer of byte arrays, `[u8; ",
@@ -118,7 +118,7 @@ macro_rules! byte_convert_traits_newtype {
 
             unsafe impl<'a, T> Adapter<T> for ConvertBytes<T, $typename, &'a dyn Adapter<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
-            T: FloatCore + ToPrimitive + 'a,
+            T: FloatCore + ToPrimitive,
             {
                 unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
                     let raw = unsafe { self.buf.read_sample_unchecked(channel, frame) };
@@ -131,7 +131,7 @@ macro_rules! byte_convert_traits_newtype {
 
             unsafe impl<'a, T> Adapter<T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
-            T: FloatCore + ToPrimitive + 'a,
+            T: FloatCore + ToPrimitive,
             {
                 unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
                     let raw = unsafe { self.buf.read_sample_unchecked(channel, frame) };
@@ -144,7 +144,7 @@ macro_rules! byte_convert_traits_newtype {
 
             unsafe impl<'a, T> AdapterMut<T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
-            T: FloatCore + ToPrimitive + 'a,
+            T: FloatCore + ToPrimitive,
             {
                 unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &T) -> bool {
                     let converted = $typename::from_scaled_float(*value);
@@ -224,8 +224,8 @@ pub struct ConvertNumbers<U, V> {
 
 impl<'a, T, U> ConvertNumbers<&'a dyn Adapter<U>, T>
 where
-    T: FloatCore + ToPrimitive + 'a,
-    U: RawSample + 'a,
+    T: FloatCore + ToPrimitive,
+    U: RawSample,
 {
     /// Create a new wrapper for a buffer implementing the [Adapter] trait,
     /// containing numerical samples.
@@ -239,8 +239,8 @@ where
 
 impl<'a, T, U> ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
 where
-    T: FloatCore + ToPrimitive + 'a,
-    U: RawSample + 'a,
+    T: FloatCore + ToPrimitive,
+    U: RawSample,
 {
     /// Create a new wrapper for a mutable buffer implementing the [AdapterMut] trait,
     /// containing numerical samples.
@@ -252,10 +252,10 @@ where
     }
 }
 
-unsafe impl<'a, T, U> Adapter<T> for ConvertNumbers<&'a dyn Adapter<U>, T>
+unsafe impl<T, U> Adapter<T> for ConvertNumbers<&dyn Adapter<U>, T>
 where
-    T: FloatCore + ToPrimitive + 'a,
-    U: RawSample + 'a,
+    T: FloatCore + ToPrimitive,
+    U: RawSample,
 {
     unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
         unsafe {
@@ -268,10 +268,10 @@ where
     implement_wrapped_size_getters!();
 }
 
-unsafe impl<'a, T, U> Adapter<T> for ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
+unsafe impl<T, U> Adapter<T> for ConvertNumbers<&mut dyn AdapterMut<U>, T>
 where
-    T: FloatCore + ToPrimitive + 'a,
-    U: RawSample + 'a,
+    T: FloatCore + ToPrimitive,
+    U: RawSample,
 {
     unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
         unsafe {
@@ -284,10 +284,10 @@ where
     implement_wrapped_size_getters!();
 }
 
-unsafe impl<'a, T, U> AdapterMut<T> for ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
+unsafe impl<T, U> AdapterMut<T> for ConvertNumbers<&mut dyn AdapterMut<U>, T>
 where
-    T: FloatCore + ToPrimitive + 'a,
-    U: RawSample + Clone + 'a,
+    T: FloatCore + ToPrimitive,
+    U: RawSample + Clone,
 {
     unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &T) -> bool {
         let converted = U::from_scaled_float(*value);

--- a/audioadapter-buffers/src/adapter_to_float.rs
+++ b/audioadapter-buffers/src/adapter_to_float.rs
@@ -76,7 +76,7 @@ where
 
 macro_rules! byte_convert_traits_newtype {
     ($typename:ident) => {
-        impl<'a, T> ConvertBytes<T, $typename, &'a dyn Adapter<'a, [u8; $typename::BYTES_PER_SAMPLE]>>
+        impl<'a, T> ConvertBytes<T, $typename, &'a dyn Adapter<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
                 T: FloatCore + ToPrimitive + 'a,
             {
@@ -86,7 +86,7 @@ macro_rules! byte_convert_traits_newtype {
                     stringify!($typename), "`]."
                 )]
                 pub fn new(
-                    buf: &'a dyn Adapter<'a, [u8; $typename::BYTES_PER_SAMPLE]>,
+                    buf: &'a dyn Adapter<[u8; $typename::BYTES_PER_SAMPLE]>,
                 ) -> Self {
                     Self {
                         _phantom: core::marker::PhantomData,
@@ -96,7 +96,7 @@ macro_rules! byte_convert_traits_newtype {
                 }
             }
 
-            impl<'a, T> ConvertBytes<T, $typename, &'a mut dyn AdapterMut<'a, [u8; $typename::BYTES_PER_SAMPLE]>>
+            impl<'a, T> ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
                 T: FloatCore + ToPrimitive + 'a,
             {
@@ -106,7 +106,7 @@ macro_rules! byte_convert_traits_newtype {
                     stringify!($typename), "`]."
                 )]
                 pub fn new_mut(
-                    buf: &'a mut dyn AdapterMut<'a, [u8; $typename::BYTES_PER_SAMPLE]>,
+                    buf: &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>,
                 ) -> Self {
                     Self {
                         _phantom: core::marker::PhantomData,
@@ -116,7 +116,7 @@ macro_rules! byte_convert_traits_newtype {
                 }
             }
 
-            unsafe impl<'a, T> Adapter<'a, T> for ConvertBytes<T, $typename, &'a dyn Adapter<'a, [u8; $typename::BYTES_PER_SAMPLE]>>
+            unsafe impl<'a, T> Adapter<T> for ConvertBytes<T, $typename, &'a dyn Adapter<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
             T: FloatCore + ToPrimitive + 'a,
             {
@@ -129,7 +129,7 @@ macro_rules! byte_convert_traits_newtype {
                 implement_wrapped_size_getters!();
             }
 
-            unsafe impl<'a, T> Adapter<'a, T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<'a, [u8; $typename::BYTES_PER_SAMPLE]>>
+            unsafe impl<'a, T> Adapter<T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
             T: FloatCore + ToPrimitive + 'a,
             {
@@ -142,7 +142,7 @@ macro_rules! byte_convert_traits_newtype {
                 implement_wrapped_size_getters!();
             }
 
-            unsafe impl<'a, T> AdapterMut<'a, T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<'a, [u8; $typename::BYTES_PER_SAMPLE]>>
+            unsafe impl<'a, T> AdapterMut<T> for ConvertBytes<T, $typename, &'a mut dyn AdapterMut<[u8; $typename::BYTES_PER_SAMPLE]>>
             where
             T: FloatCore + ToPrimitive + 'a,
             {
@@ -222,14 +222,14 @@ pub struct ConvertNumbers<U, V> {
     buf: U,
 }
 
-impl<'a, T, U> ConvertNumbers<&'a dyn Adapter<'a, U>, T>
+impl<'a, T, U> ConvertNumbers<&'a dyn Adapter<U>, T>
 where
     T: FloatCore + ToPrimitive + 'a,
     U: RawSample + 'a,
 {
     /// Create a new wrapper for a buffer implementing the [Adapter] trait,
     /// containing numerical samples.
-    pub fn new(buf: &'a dyn Adapter<'a, U>) -> Self {
+    pub fn new(buf: &'a dyn Adapter<U>) -> Self {
         Self {
             _phantom: core::marker::PhantomData,
             buf,
@@ -237,14 +237,14 @@ where
     }
 }
 
-impl<'a, T, U> ConvertNumbers<&'a mut dyn AdapterMut<'a, U>, T>
+impl<'a, T, U> ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
 where
     T: FloatCore + ToPrimitive + 'a,
     U: RawSample + 'a,
 {
     /// Create a new wrapper for a mutable buffer implementing the [AdapterMut] trait,
     /// containing numerical samples.
-    pub fn new_mut(buf: &'a mut dyn AdapterMut<'a, U>) -> Self {
+    pub fn new_mut(buf: &'a mut dyn AdapterMut<U>) -> Self {
         Self {
             _phantom: core::marker::PhantomData,
             buf,
@@ -252,7 +252,7 @@ where
     }
 }
 
-unsafe impl<'a, T, U> Adapter<'a, T> for ConvertNumbers<&'a dyn Adapter<'a, U>, T>
+unsafe impl<'a, T, U> Adapter<T> for ConvertNumbers<&'a dyn Adapter<U>, T>
 where
     T: FloatCore + ToPrimitive + 'a,
     U: RawSample + 'a,
@@ -268,7 +268,7 @@ where
     implement_wrapped_size_getters!();
 }
 
-unsafe impl<'a, T, U> Adapter<'a, T> for ConvertNumbers<&'a mut dyn AdapterMut<'a, U>, T>
+unsafe impl<'a, T, U> Adapter<T> for ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
 where
     T: FloatCore + ToPrimitive + 'a,
     U: RawSample + 'a,
@@ -284,7 +284,7 @@ where
     implement_wrapped_size_getters!();
 }
 
-unsafe impl<'a, T, U> AdapterMut<'a, T> for ConvertNumbers<&'a mut dyn AdapterMut<'a, U>, T>
+unsafe impl<'a, T, U> AdapterMut<T> for ConvertNumbers<&'a mut dyn AdapterMut<U>, T>
 where
     T: FloatCore + ToPrimitive + 'a,
     U: RawSample + Clone + 'a,

--- a/audioadapter-buffers/src/direct.rs
+++ b/audioadapter-buffers/src/direct.rs
@@ -160,7 +160,7 @@ impl<'a, T> SequentialSliceOfVecs<&'a mut [Vec<T>]> {
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSliceOfVecs<&'a [Vec<T>]>
+unsafe impl<T> Adapter<T> for SequentialSliceOfVecs<&[Vec<T>]>
 where
     T: Clone,
 {
@@ -185,7 +185,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSliceOfVecs<&'a mut [Vec<T>]>
+unsafe impl<T> Adapter<T> for SequentialSliceOfVecs<&mut [Vec<T>]>
 where
     T: Clone,
 {
@@ -210,7 +210,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> AdapterMut<'a, T> for SequentialSliceOfVecs<&'a mut [Vec<T>]>
+unsafe impl<T> AdapterMut<T> for SequentialSliceOfVecs<&mut [Vec<T>]>
 where
     T: Clone,
 {
@@ -361,7 +361,7 @@ impl<'a, T> SparseSequentialSliceOfVecs<'a, &'a mut [Vec<T>]> {
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for SparseSequentialSliceOfVecs<'a, &'a [Vec<T>]>
+unsafe impl<'a, T> Adapter<T> for SparseSequentialSliceOfVecs<'a, &'a [Vec<T>]>
 where
     T: Clone + Default,
 {
@@ -389,7 +389,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for SparseSequentialSliceOfVecs<'a, &'a mut [Vec<T>]>
+unsafe impl<'a, T> Adapter<T> for SparseSequentialSliceOfVecs<'a, &'a mut [Vec<T>]>
 where
     T: Clone + Default,
 {
@@ -417,7 +417,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> AdapterMut<'a, T> for SparseSequentialSliceOfVecs<'a, &'a mut [Vec<T>]>
+unsafe impl<'a, T> AdapterMut<T> for SparseSequentialSliceOfVecs<'a, &'a mut [Vec<T>]>
 where
     T: Clone + Default,
 {
@@ -555,7 +555,7 @@ impl<'a, T> SequentialSliceOfSlices<&'a mut [&'a mut [T]]> {
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSliceOfSlices<&'a [&'a [T]]>
+unsafe impl<'a, T> Adapter<T> for SequentialSliceOfSlices<&'a [&'a [T]]>
 where
     T: Clone,
 {
@@ -579,7 +579,7 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSliceOfSlices<&'a mut [&'a mut [T]]>
+unsafe impl<'a, T> Adapter<T> for SequentialSliceOfSlices<&'a mut [&'a mut [T]]>
 where
     T: Clone,
 {
@@ -603,7 +603,7 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for SequentialSliceOfSlices<&'a mut [&'a mut [T]]>
+unsafe impl<'a, T> AdapterMut<T> for SequentialSliceOfSlices<&'a mut [&'a mut [T]]>
 where
     T: Clone,
 {
@@ -750,7 +750,7 @@ impl<'a, T> SparseSequentialSliceOfSlices<'a, &'a mut [&'a mut [T]]> {
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SparseSequentialSliceOfSlices<'a, &'a [&'a [T]]>
+unsafe impl<'a, T> Adapter<T> for SparseSequentialSliceOfSlices<'a, &'a [&'a [T]]>
 where
     T: Clone + Default,
 {
@@ -777,7 +777,7 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SparseSequentialSliceOfSlices<'a, &'a mut [&'a mut [T]]>
+unsafe impl<'a, T> Adapter<T> for SparseSequentialSliceOfSlices<'a, &'a mut [&'a mut [T]]>
 where
     T: Clone + Default,
 {
@@ -804,7 +804,7 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for SparseSequentialSliceOfSlices<'a, &'a mut [&'a mut [T]]>
+unsafe impl<'a, T> AdapterMut<T> for SparseSequentialSliceOfSlices<'a, &'a mut [&'a mut [T]]>
 where
     T: Clone + Default,
 {
@@ -946,7 +946,7 @@ impl<'a, T> InterleavedSliceOfVecs<&'a mut [Vec<T>]> {
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for InterleavedSliceOfVecs<&'a [Vec<T>]>
+unsafe impl<T> Adapter<T> for InterleavedSliceOfVecs<&[Vec<T>]>
 where
     T: Clone,
 {
@@ -972,7 +972,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> Adapter<'a, T> for InterleavedSliceOfVecs<&'a mut [Vec<T>]>
+unsafe impl<T> Adapter<T> for InterleavedSliceOfVecs<&mut [Vec<T>]>
 where
     T: Clone,
 {
@@ -998,7 +998,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> AdapterMut<'a, T> for InterleavedSliceOfVecs<&'a mut [Vec<T>]>
+unsafe impl<T> AdapterMut<T> for InterleavedSliceOfVecs<&mut [Vec<T>]>
 where
     T: Clone,
 {
@@ -1120,7 +1120,7 @@ impl<'a, T> InterleavedSlice<&'a mut [T]> {
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for InterleavedSlice<&'a [T]>
+unsafe impl<T> Adapter<T> for InterleavedSlice<&[T]>
 where
     T: Clone,
 {
@@ -1147,7 +1147,7 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for InterleavedSlice<&'a mut [T]>
+unsafe impl<T> Adapter<T> for InterleavedSlice<&mut [T]>
 where
     T: Clone,
 {
@@ -1174,7 +1174,7 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for InterleavedSlice<&'a mut [T]>
+unsafe impl<T> AdapterMut<T> for InterleavedSlice<&mut [T]>
 where
     T: Clone,
 {
@@ -1316,7 +1316,7 @@ impl<'a, T> SequentialSlice<&'a mut [T]> {
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSlice<&'a [T]>
+unsafe impl<T> Adapter<T> for SequentialSlice<&[T]>
 where
     T: Clone,
 {
@@ -1344,7 +1344,7 @@ where
 }
 
 // Implement also for mutable version, identical to the immutable impl.
-unsafe impl<'a, T> Adapter<'a, T> for SequentialSlice<&'a mut [T]>
+unsafe impl<T> Adapter<T> for SequentialSlice<&mut [T]>
 where
     T: Clone,
 {
@@ -1371,7 +1371,7 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for SequentialSlice<&'a mut [T]>
+unsafe impl<T> AdapterMut<T> for SequentialSlice<&mut [T]>
 where
     T: Clone,
 {

--- a/audioadapter-buffers/src/direct.rs
+++ b/audioadapter-buffers/src/direct.rs
@@ -240,7 +240,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for ch in self.buf.iter_mut() {
@@ -449,7 +449,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for (ch, active) in self.buf.iter_mut().zip(self.mask.iter()) {
@@ -633,7 +633,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for ch in self.buf.iter_mut() {
@@ -836,7 +836,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for (ch, active) in self.buf.iter_mut().zip(self.mask.iter()) {
@@ -1207,7 +1207,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         unsafe {
@@ -1404,7 +1404,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for ch in 0..self.channels {
@@ -1974,5 +1974,40 @@ mod tests {
             ),
             "expected SizeError::Mask with required length 2, got {err:?}"
         );
+    }
+
+    #[test]
+    fn overflowing_dimensions_are_rejected() {
+        // channels * frames overflows usize and must not wrap to a small
+        // value that passes the length check. See the soundness fix in
+        // `check_slice_length!`.
+        let data = [0_i32; 4];
+        // big * big wraps to exactly 0 (2^usize::BITS), which the unfixed check
+        // would treat as "required 0" and accept. Portable across 32/64-bit.
+        let big = 1_usize << (usize::BITS / 2);
+        assert!(
+            matches!(
+                InterleavedSlice::new(&data, big, big),
+                Err(SizeError::Total { .. })
+            ),
+            "overflowing channels * frames must be rejected"
+        );
+        assert!(
+            matches!(
+                SequentialSlice::new(&data, big, big),
+                Err(SizeError::Total { .. })
+            ),
+            "overflowing channels * frames must be rejected"
+        );
+    }
+
+    #[test]
+    fn copy_frames_within_rejects_overflowing_range() {
+        // src + count overflows usize. The guard must not wrap and allow an
+        // out-of-bounds copy.
+        let mut data = [0_i32; 6];
+        let mut buf = InterleavedSlice::new_mut(&mut data, 2, 3).unwrap();
+        assert_eq!(buf.copy_frames_within(usize::MAX, 0, 2), None);
+        assert_eq!(buf.copy_frames_within(0, usize::MAX, 2), None);
     }
 }

--- a/audioadapter-buffers/src/dummy.rs
+++ b/audioadapter-buffers/src/dummy.rs
@@ -28,9 +28,9 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for Dummy<T>
+unsafe impl<T> Adapter<T> for Dummy<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn read_sample_unchecked(&self, _channel: usize, _frame: usize) -> T {
         self.default.clone()
@@ -39,9 +39,9 @@ where
     implement_size_getters!();
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for Dummy<T>
+unsafe impl<T> AdapterMut<T> for Dummy<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn write_sample_unchecked(
         &mut self,

--- a/audioadapter-buffers/src/lib.rs
+++ b/audioadapter-buffers/src/lib.rs
@@ -141,18 +141,24 @@ pub(crate) use implement_size_getters;
 
 macro_rules! check_slice_length {
     ($channels:expr , $frames:expr, $length:expr ) => {
-        if $length < $frames * $channels {
+        // Saturating, so an overflowing product becomes `usize::MAX` and the
+        // check fails instead of wrapping to a small value and passing.
+        let required = $frames.saturating_mul($channels);
+        if $length < required {
             return Err(SizeError::Total {
                 actual: $length,
-                required: $frames * $channels,
+                required,
             });
         }
     };
     ($channels:expr , $frames:expr, $length:expr, $elements_per_sample:expr) => {
-        if $length < $frames * $channels * $elements_per_sample {
+        let required = $frames
+            .saturating_mul($channels)
+            .saturating_mul($elements_per_sample);
+        if $length < required {
             return Err(SizeError::Total {
                 actual: $length,
-                required: $frames * $channels * $elements_per_sample,
+                required,
             });
         }
     };

--- a/audioadapter-buffers/src/lib.rs
+++ b/audioadapter-buffers/src/lib.rs
@@ -16,6 +16,10 @@ pub mod owned;
 /// Dummy Adapter
 pub mod dummy;
 
+/// Utility helpers for working with adapters, currently for copying samples
+/// between an adapter and a plain interleaved or sequential slice.
+pub mod utils;
+
 /// Sample format types re-exported from [`audioadapter_sample`].
 ///
 /// These are the byte-wrapper types (`I16_LE`, `I24_LE`, `F32_LE`, …) used with

--- a/audioadapter-buffers/src/lib.rs
+++ b/audioadapter-buffers/src/lib.rs
@@ -16,6 +16,14 @@ pub mod owned;
 /// Dummy Adapter
 pub mod dummy;
 
+/// Sample format types re-exported from [`audioadapter_sample`].
+///
+/// These are the byte-wrapper types (`I16_LE`, `I24_LE`, `F32_LE`, …) used with
+/// the byte-based constructors and converters in [`number_to_float`] and
+/// [`adapter_to_float`]. They are re-exported here so that you do not need to add
+/// a separate dependency on `audioadapter-sample` just to name a format.
+pub use audioadapter_sample::sample;
+
 mod slicetools;
 
 use core::error::Error;

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -67,11 +67,15 @@ use crate::SizeError;
 use crate::slicetools::copy_within_slice;
 use crate::{check_slice_length, implement_size_getters};
 use audioadapter::{Adapter, AdapterMut};
-use audioadapter_sample::sample::RawSample;
+use audioadapter_sample::sample::{BytesSample, RawSample};
 
 /// A macro for creating a view of an immutable slice of bytes
 /// as a different type.
-#[macro_export]
+///
+/// This is **not** exported: it transmutes `&[u8]` into `&[$type]` with no
+/// trait bounds, so it is only sound for types with alignment 1 and no
+/// validity invariants. The internal call sites guarantee this by requiring
+/// `$type: BytesSample`, which is only implemented for such byte-wrapper types.
 macro_rules! byte_slice_as_type {
     ($slice:ident, $type:ty) => {
         unsafe {
@@ -84,7 +88,11 @@ macro_rules! byte_slice_as_type {
 
 /// A macro for creating a view of a mutable slice of bytes
 /// as a different type.
-#[macro_export]
+///
+/// This is **not** exported: it transmutes `&mut [u8]` into `&mut [$type]`
+/// with no trait bounds, so it is only sound for types with alignment 1 and
+/// no validity invariants. The internal call sites guarantee this by requiring
+/// `$type: BytesSample`, which is only implemented for such byte-wrapper types.
 macro_rules! byte_slice_as_type_mut {
     ($slice:ident, $type:ty) => {
         unsafe {
@@ -96,6 +104,13 @@ macro_rules! byte_slice_as_type_mut {
 }
 
 /// A wrapper for a slice containing interleaved numerical samples.
+///
+/// # Type parameters
+/// - `U`: the wrapped slice type holding the samples, for example `&[i16]`,
+///   `&mut [i16]`, or `&[I16_LE]` for the byte-based constructors. The element
+///   type implements [RawSample] (and [BytesSample] when constructing from bytes).
+/// - `V`: the floating point type that samples are converted to and from when
+///   reading and writing, for example `f32` or `f64`.
 pub struct InterleavedNumbers<U, V> {
     _phantom: core::marker::PhantomData<V>,
     buf: U,
@@ -103,7 +118,14 @@ pub struct InterleavedNumbers<U, V> {
     channels: usize,
 }
 
-/// A wrapper for a slice containing interleaved numerical samples.
+/// A wrapper for a slice containing sequential numerical samples.
+///
+/// # Type parameters
+/// - `U`: the wrapped slice type holding the samples, for example `&[i16]`,
+///   `&mut [i16]`, or `&[I16_LE]` for the byte-based constructors. The element
+///   type implements [RawSample] (and [BytesSample] when constructing from bytes).
+/// - `V`: the floating point type that samples are converted to and from when
+///   reading and writing, for example `f32` or `f64`.
 pub struct SequentialNumbers<U, V> {
     _phantom: core::marker::PhantomData<V>,
     buf: U,
@@ -144,8 +166,8 @@ where
         })
     }
 
-    /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [RawSample],
+    /// Create a new wrapper for an immutable slice
+    /// of numerical samples implementing [BytesSample],
     /// stored as raw bytes in _interleaved_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -155,7 +177,10 @@ where
         buf: &'a [u8],
         channels: usize,
         frames: usize,
-    ) -> Result<Self, SizeError> {
+    ) -> Result<Self, SizeError>
+    where
+        U: BytesSample,
+    {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type!(buf, U);
         Ok(Self {
@@ -190,7 +215,7 @@ where
     }
 
     /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [RawSample],
+    /// of numerical samples implementing [BytesSample],
     /// stored as raw bytes in _interleaved_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -200,7 +225,10 @@ where
         buf: &'a mut [u8],
         channels: usize,
         frames: usize,
-    ) -> Result<Self, SizeError> {
+    ) -> Result<Self, SizeError>
+    where
+        U: BytesSample,
+    {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type_mut!(buf, U);
         Ok(Self {
@@ -248,8 +276,8 @@ where
         })
     }
 
-    /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [RawSample],
+    /// Create a new wrapper for an immutable slice
+    /// of numerical samples implementing [BytesSample],
     /// stored as raw bytes in _sequential_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -259,7 +287,10 @@ where
         buf: &'a [u8],
         channels: usize,
         frames: usize,
-    ) -> Result<Self, SizeError> {
+    ) -> Result<Self, SizeError>
+    where
+        U: BytesSample,
+    {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type!(buf, U);
         Ok(Self {
@@ -294,7 +325,7 @@ where
     }
 
     /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [RawSample],
+    /// of numerical samples implementing [BytesSample],
     /// stored as raw bytes in _sequential_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -304,7 +335,10 @@ where
         buf: &'a mut [u8],
         channels: usize,
         frames: usize,
-    ) -> Result<Self, SizeError> {
+    ) -> Result<Self, SizeError>
+    where
+        U: BytesSample,
+    {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type_mut!(buf, U);
         Ok(Self {

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -173,11 +173,7 @@ where
     /// It is allowed to be longer than needed,
     /// but these extra values cannot
     /// be accessed via the `Adapter` trait methods.
-    pub fn new_from_bytes(
-        buf: &'a [u8],
-        channels: usize,
-        frames: usize,
-    ) -> Result<Self, SizeError>
+    pub fn new_from_bytes(buf: &'a [u8], channels: usize, frames: usize) -> Result<Self, SizeError>
     where
         U: BytesSample,
     {
@@ -283,11 +279,7 @@ where
     /// It is allowed to be longer than needed,
     /// but these extra values cannot
     /// be accessed via the `Adapter` trait methods.
-    pub fn new_from_bytes(
-        buf: &'a [u8],
-        channels: usize,
-        frames: usize,
-    ) -> Result<Self, SizeError>
+    pub fn new_from_bytes(buf: &'a [u8], channels: usize, frames: usize) -> Result<Self, SizeError>
     where
         U: BytesSample,
     {

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -399,7 +399,7 @@ where
 
 macro_rules! impl_traits_newtype {
     ($structname:ident) => {
-        unsafe impl<'a, T, U> Adapter<'a, T> for $structname<&'a [U], T>
+        unsafe impl<'a, T, U> Adapter<T> for $structname<&'a [U], T>
         where
             T: FloatCore + ToPrimitive + 'a,
             U: RawSample,
@@ -412,7 +412,7 @@ macro_rules! impl_traits_newtype {
             implement_size_getters!();
         }
 
-        unsafe impl<'a, T, U> Adapter<'a, T> for $structname<&'a mut [U], T>
+        unsafe impl<'a, T, U> Adapter<T> for $structname<&'a mut [U], T>
         where
             T: FloatCore + ToPrimitive + 'a,
             U: RawSample,
@@ -425,7 +425,7 @@ macro_rules! impl_traits_newtype {
             implement_size_getters!();
         }
 
-        unsafe impl<'a, T, U> AdapterMut<'a, T> for $structname<&'a mut [U], T>
+        unsafe impl<'a, T, U> AdapterMut<T> for $structname<&'a mut [U], T>
         where
             T: FloatCore + ToPrimitive + 'a,
             U: RawSample + Clone,

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -72,13 +72,20 @@ use audioadapter_sample::sample::{BytesSample, RawSample};
 /// A macro for creating a view of an immutable slice of bytes
 /// as a different type.
 ///
-/// This is **not** exported: it transmutes `&[u8]` into `&[$type]` with no
-/// trait bounds, so it is only sound for types with alignment 1 and no
-/// validity invariants. The internal call sites guarantee this by requiring
-/// `$type: BytesSample`, which is only implemented for such byte-wrapper types.
+/// This is **not** exported: it transmutes `&[u8]` into `&[$type]`, which is
+/// only sound for types with alignment 1 and no validity invariants. Alignment
+/// is verified at compile time by the `const` assert below, and the internal
+/// call sites only ever use the library's `BytesSample` byte-wrapper types,
+/// which are `[u8; N]` newtypes where every bit pattern is valid.
 macro_rules! byte_slice_as_type {
     ($slice:ident, $type:ty) => {
         unsafe {
+            const {
+                assert!(
+                    core::mem::align_of::<$type>() == 1,
+                    "type must have alignment 1"
+                )
+            };
             let ptr = $slice.as_ptr() as *const $type;
             let len = $slice.len();
             core::slice::from_raw_parts(ptr, len / core::mem::size_of::<$type>())
@@ -89,13 +96,20 @@ macro_rules! byte_slice_as_type {
 /// A macro for creating a view of a mutable slice of bytes
 /// as a different type.
 ///
-/// This is **not** exported: it transmutes `&mut [u8]` into `&mut [$type]`
-/// with no trait bounds, so it is only sound for types with alignment 1 and
-/// no validity invariants. The internal call sites guarantee this by requiring
-/// `$type: BytesSample`, which is only implemented for such byte-wrapper types.
+/// This is **not** exported: it transmutes `&mut [u8]` into `&mut [$type]`,
+/// which is only sound for types with alignment 1 and no validity invariants.
+/// Alignment is verified at compile time by the `const` assert below, and the
+/// internal call sites only ever use the library's `BytesSample` byte-wrapper
+/// types, which are `[u8; N]` newtypes where every bit pattern is valid.
 macro_rules! byte_slice_as_type_mut {
     ($slice:ident, $type:ty) => {
         unsafe {
+            const {
+                assert!(
+                    core::mem::align_of::<$type>() == 1,
+                    "type must have alignment 1"
+                )
+            };
             let ptr = $slice.as_mut_ptr() as *mut $type;
             let len = $slice.len();
             core::slice::from_raw_parts_mut(ptr, len / core::mem::size_of::<$type>())

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -278,7 +278,7 @@ where
     }
 
     fn copy_frames_within_impl(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         unsafe {
@@ -384,7 +384,7 @@ where
     }
 
     fn copy_frames_within_impl(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for ch in 0..self.channels {

--- a/audioadapter-buffers/src/number_to_float.rs
+++ b/audioadapter-buffers/src/number_to_float.rs
@@ -67,25 +67,23 @@ use crate::SizeError;
 use crate::slicetools::copy_within_slice;
 use crate::{check_slice_length, implement_size_getters};
 use audioadapter::{Adapter, AdapterMut};
-use audioadapter_sample::sample::{BytesSample, RawSample};
+use audioadapter_sample::sample::{
+    BytesSample, F32_BE, F32_LE, F64_BE, F64_LE, I16_BE, I16_LE, I24_4LJ_BE, I24_4LJ_LE,
+    I24_4RJ_BE, I24_4RJ_LE, I24_BE, I24_LE, I32_BE, I32_LE, I64_BE, I64_LE, RawSample, U16_BE,
+    U16_LE, U24_4LJ_BE, U24_4LJ_LE, U24_4RJ_BE, U24_4RJ_LE, U24_BE, U24_LE, U32_BE, U32_LE, U64_BE,
+    U64_LE,
+};
 
 /// A macro for creating a view of an immutable slice of bytes
 /// as a different type.
 ///
 /// This is **not** exported: it transmutes `&[u8]` into `&[$type]`, which is
-/// only sound for types with alignment 1 and no validity invariants. Alignment
-/// is verified at compile time by the `const` assert below, and the internal
-/// call sites only ever use the library's `BytesSample` byte-wrapper types,
-/// which are `[u8; N]` newtypes where every bit pattern is valid.
+/// only sound for types with alignment 1 and no validity invariants. Callers
+/// must therefore require `$type: PlainBytes`, whose unsafe contract guarantees
+/// exactly those properties.
 macro_rules! byte_slice_as_type {
     ($slice:ident, $type:ty) => {
         unsafe {
-            const {
-                assert!(
-                    core::mem::align_of::<$type>() == 1,
-                    "type must have alignment 1"
-                )
-            };
             let ptr = $slice.as_ptr() as *const $type;
             let len = $slice.len();
             core::slice::from_raw_parts(ptr, len / core::mem::size_of::<$type>())
@@ -98,18 +96,11 @@ macro_rules! byte_slice_as_type {
 ///
 /// This is **not** exported: it transmutes `&mut [u8]` into `&mut [$type]`,
 /// which is only sound for types with alignment 1 and no validity invariants.
-/// Alignment is verified at compile time by the `const` assert below, and the
-/// internal call sites only ever use the library's `BytesSample` byte-wrapper
-/// types, which are `[u8; N]` newtypes where every bit pattern is valid.
+/// Callers must therefore require `$type: PlainBytes`, whose unsafe contract
+/// guarantees exactly those properties.
 macro_rules! byte_slice_as_type_mut {
     ($slice:ident, $type:ty) => {
         unsafe {
-            const {
-                assert!(
-                    core::mem::align_of::<$type>() == 1,
-                    "type must have alignment 1"
-                )
-            };
             let ptr = $slice.as_mut_ptr() as *mut $type;
             let len = $slice.len();
             core::slice::from_raw_parts_mut(ptr, len / core::mem::size_of::<$type>())
@@ -117,12 +108,49 @@ macro_rules! byte_slice_as_type_mut {
     };
 }
 
+/// Marker trait for sample types whose raw byte representation can be viewed
+/// directly as the type, enabling the byte-based constructors.
+///
+/// # Safety
+/// The byte-based constructors
+/// ([`InterleavedNumbers::new_from_bytes`], [`InterleavedNumbers::new_from_bytes_mut`],
+/// [`SequentialNumbers::new_from_bytes`], [`SequentialNumbers::new_from_bytes_mut`])
+/// reinterpret a `&[u8]` as a `&[Self]` without copying. For that to be sound,
+/// every implementor must guarantee that:
+///
+/// - `Self` has an alignment of 1, and
+/// - every bit pattern of the matching size is a valid value of `Self`, i.e. it
+///   is a plain "bag of bytes" with no validity invariants and no padding.
+///
+/// All the byte-wrapper sample types in [`audioadapter_sample`] are
+/// `[u8; N]` newtypes that satisfy both requirements, and this trait is
+/// implemented for all of them. If you implement [BytesSample] for your own
+/// type and want to use it with those constructors, implement this trait too,
+/// upholding the requirements above.
+pub unsafe trait PlainBytes: BytesSample {}
+
+macro_rules! impl_plainbytes {
+    ($($t:ty),* $(,)?) => {
+        $(
+            // SAFETY: each type is a `#[derive(..)]` newtype around `[u8; N]`,
+            // which has alignment 1 and is valid for every bit pattern.
+            unsafe impl PlainBytes for $t {}
+        )*
+    };
+}
+
+impl_plainbytes!(
+    I16_LE, I16_BE, U16_LE, U16_BE, I24_LE, I24_BE, U24_LE, U24_BE, I24_4LJ_LE, I24_4LJ_BE,
+    I24_4RJ_LE, I24_4RJ_BE, U24_4LJ_LE, U24_4LJ_BE, U24_4RJ_LE, U24_4RJ_BE, I32_LE, I32_BE, U32_LE,
+    U32_BE, I64_LE, I64_BE, U64_LE, U64_BE, F32_LE, F32_BE, F64_LE, F64_BE,
+);
+
 /// A wrapper for a slice containing interleaved numerical samples.
 ///
 /// # Type parameters
 /// - `U`: the wrapped slice type holding the samples, for example `&[i16]`,
 ///   `&mut [i16]`, or `&[I16_LE]` for the byte-based constructors. The element
-///   type implements [RawSample] (and [BytesSample] when constructing from bytes).
+///   type implements [RawSample] (and [PlainBytes] when constructing from bytes).
 /// - `V`: the floating point type that samples are converted to and from when
 ///   reading and writing, for example `f32` or `f64`.
 pub struct InterleavedNumbers<U, V> {
@@ -137,7 +165,7 @@ pub struct InterleavedNumbers<U, V> {
 /// # Type parameters
 /// - `U`: the wrapped slice type holding the samples, for example `&[i16]`,
 ///   `&mut [i16]`, or `&[I16_LE]` for the byte-based constructors. The element
-///   type implements [RawSample] (and [BytesSample] when constructing from bytes).
+///   type implements [RawSample] (and [PlainBytes] when constructing from bytes).
 /// - `V`: the floating point type that samples are converted to and from when
 ///   reading and writing, for example `f32` or `f64`.
 pub struct SequentialNumbers<U, V> {
@@ -181,7 +209,7 @@ where
     }
 
     /// Create a new wrapper for an immutable slice
-    /// of numerical samples implementing [BytesSample],
+    /// of numerical samples implementing [PlainBytes],
     /// stored as raw bytes in _interleaved_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -189,7 +217,7 @@ where
     /// be accessed via the `Adapter` trait methods.
     pub fn new_from_bytes(buf: &'a [u8], channels: usize, frames: usize) -> Result<Self, SizeError>
     where
-        U: BytesSample,
+        U: PlainBytes,
     {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type!(buf, U);
@@ -225,7 +253,7 @@ where
     }
 
     /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [BytesSample],
+    /// of numerical samples implementing [PlainBytes],
     /// stored as raw bytes in _interleaved_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -237,7 +265,7 @@ where
         frames: usize,
     ) -> Result<Self, SizeError>
     where
-        U: BytesSample,
+        U: PlainBytes,
     {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type_mut!(buf, U);
@@ -287,7 +315,7 @@ where
     }
 
     /// Create a new wrapper for an immutable slice
-    /// of numerical samples implementing [BytesSample],
+    /// of numerical samples implementing [PlainBytes],
     /// stored as raw bytes in _sequential_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -295,7 +323,7 @@ where
     /// be accessed via the `Adapter` trait methods.
     pub fn new_from_bytes(buf: &'a [u8], channels: usize, frames: usize) -> Result<Self, SizeError>
     where
-        U: BytesSample,
+        U: PlainBytes,
     {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type!(buf, U);
@@ -331,7 +359,7 @@ where
     }
 
     /// Create a new wrapper for a mutable slice
-    /// of numerical samples implementing [BytesSample],
+    /// of numerical samples implementing [PlainBytes],
     /// stored as raw bytes in _sequential_ order.
     /// The slice length must be at least `core::mem::size_of::<U>() * frames * channels`.
     /// It is allowed to be longer than needed,
@@ -343,7 +371,7 @@ where
         frames: usize,
     ) -> Result<Self, SizeError>
     where
-        U: BytesSample,
+        U: PlainBytes,
     {
         check_slice_length!(channels, frames, buf.len(), size_of::<U>());
         let buf_view = byte_slice_as_type_mut!(buf, U);

--- a/audioadapter-buffers/src/owned.rs
+++ b/audioadapter-buffers/src/owned.rs
@@ -68,7 +68,7 @@ impl<T> InterleavedOwned<T>
 where
     T: Clone,
 {
-    /// Create a new `InterleavedOwned` by allocaing a new vector filled with `value`.
+    /// Create a new `InterleavedOwned` by allocating a new vector filled with `value`.
     ///
     /// Panics if `channels * frames` overflows `usize`.
     pub fn new(value: T, channels: usize, frames: usize) -> Self {
@@ -243,7 +243,7 @@ impl<T> SequentialOwned<T>
 where
     T: Clone,
 {
-    /// Create a new `SequentialOwned` by allocaing a new vector filled with `value`.
+    /// Create a new `SequentialOwned` by allocating a new vector filled with `value`.
     ///
     /// Panics if `channels * frames` overflows `usize`.
     pub fn new(value: T, channels: usize, frames: usize) -> Self {

--- a/audioadapter-buffers/src/owned.rs
+++ b/audioadapter-buffers/src/owned.rs
@@ -69,8 +69,13 @@ where
     T: Clone,
 {
     /// Create a new `InterleavedOwned` by allocaing a new vector filled with `value`.
+    ///
+    /// Panics if `channels * frames` overflows `usize`.
     pub fn new(value: T, channels: usize, frames: usize) -> Self {
-        let buf = vec![value; channels * frames];
+        let len = channels
+            .checked_mul(frames)
+            .expect("channels * frames overflows usize");
+        let buf = vec![value; len];
         Self {
             buf,
             frames,
@@ -157,7 +162,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         unsafe {
@@ -239,8 +244,13 @@ where
     T: Clone,
 {
     /// Create a new `SequentialOwned` by allocaing a new vector filled with `value`.
+    ///
+    /// Panics if `channels * frames` overflows `usize`.
     pub fn new(value: T, channels: usize, frames: usize) -> Self {
-        let buf = vec![value; channels * frames];
+        let len = channels
+            .checked_mul(frames)
+            .expect("channels * frames overflows usize");
+        let buf = vec![value; len];
         Self {
             buf,
             frames,
@@ -327,7 +337,7 @@ where
     }
 
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames || dest + count > self.frames {
+        if count > self.frames || src > self.frames - count || dest > self.frames - count {
             return None;
         }
         for ch in 0..self.channels {
@@ -568,5 +578,21 @@ mod tests {
     fn test_sequential_owned_with_generic_tester() {
         let mut buffer = SequentialOwned::new(0usize, 2, 4);
         test_adapter_mut_methods(&mut buffer);
+    }
+
+    #[test]
+    #[should_panic(expected = "overflows usize")]
+    fn interleaved_owned_new_panics_on_overflow() {
+        // channels * frames overflows usize: must panic, not wrap to a small
+        // allocation while claiming the large dimensions.
+        let big = 1_usize << (usize::BITS / 2);
+        let _ = InterleavedOwned::new(0_i32, big, big);
+    }
+
+    #[test]
+    #[should_panic(expected = "overflows usize")]
+    fn sequential_owned_new_panics_on_overflow() {
+        let big = 1_usize << (usize::BITS / 2);
+        let _ = SequentialOwned::new(0_i32, big, big);
     }
 }

--- a/audioadapter-buffers/src/owned.rs
+++ b/audioadapter-buffers/src/owned.rs
@@ -102,9 +102,9 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for InterleavedOwned<T>
+unsafe impl<T> Adapter<T> for InterleavedOwned<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
         let index = self.calc_index(channel, frame);
@@ -129,9 +129,9 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for InterleavedOwned<T>
+unsafe impl<T> AdapterMut<T> for InterleavedOwned<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &T) -> bool {
         let index = self.calc_index(channel, frame);
@@ -277,9 +277,9 @@ where
     }
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for SequentialOwned<T>
+unsafe impl<T> Adapter<T> for SequentialOwned<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
         let index = self.calc_index(channel, frame);
@@ -304,9 +304,9 @@ where
     }
 }
 
-unsafe impl<'a, T> AdapterMut<'a, T> for SequentialOwned<T>
+unsafe impl<T> AdapterMut<T> for SequentialOwned<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &T) -> bool {
         let index = self.calc_index(channel, frame);

--- a/audioadapter-buffers/src/utils.rs
+++ b/audioadapter-buffers/src/utils.rs
@@ -1,0 +1,294 @@
+//! A collection of utilities for working with adapters.
+//!
+//! This module gathers small helpers that build on the adapter traits. For now
+//! that is just the slice-copy functions described below; more may be added
+//! over time.
+//!
+//! # Copying between an adapter and a plain slice
+//!
+//! The `to_interleaved`, `to_sequential`, `from_interleaved`, and
+//! `from_sequential` functions bridge the common case where a caller holds a
+//! raw `&[T]` or `&mut [T]` in a known memory layout (interleaved or sequential)
+//! and wants to copy it to or from an `Adapter`/`AdapterMut`, without wrapping
+//! the slice by hand. Only the slice side is a fixed layout; the other side is
+//! an arbitrary adapter, so it can be any layout or sample format, including the
+//! converting wrappers in [`crate::adapter_to_float`] and the sparse buffers in
+//! [`crate::direct`].
+//!
+//! Each helper works like
+//! [`AdapterMut::copy_from_other`](audioadapter::AdapterMut::copy_from_other):
+//! it takes a `src_skip`, a `dst_skip`, and a `take`, copies `take` frames for
+//! all channels, and returns the number of samples clipped during conversion,
+//! or `None` if the requested region does not fit in either the adapter or the
+//! slice. The slice carries its own frame count (`slice.len() / channels`); a
+//! slice longer than a whole number of frames keeps the convention of the
+//! buffer wrappers, with the trailing partial frame left unused.
+//!
+//! Note that a same-type interleaved-to-sequential copy of two plain slices is
+//! just a transpose and does not need an adapter at all. These helpers earn
+//! their place only because the adapter side is unconstrained: it may relayout,
+//! convert the sample format, or be sparse.
+//!
+//! ## Sparse buffers
+//!
+//! The sparse buffers in [`crate::direct`] report their full channel count but
+//! only store some channels. They compose cleanly here:
+//!
+//! - As a source, absent channels read back as `T::default()`, so
+//!   `to_interleaved` and `to_sequential` write zeros into the output slice
+//!   for those channels.
+//! - As a destination, writes to absent channels are dropped, so
+//!   `from_interleaved` and `from_sequential` simply skip the samples that
+//!   have nowhere to go.
+//!
+//! Both directions stay in bounds and never panic.
+
+use audioadapter::{Adapter, AdapterMut};
+
+use crate::direct::{InterleavedSlice, SequentialSlice};
+
+/// Number of whole frames a flat slice of `len` samples holds for `channels`
+/// channels. Zero channels yields zero frames rather than dividing by zero.
+fn slice_frames(len: usize, channels: usize) -> usize {
+    if channels == 0 { 0 } else { len / channels }
+}
+
+/// Copy `take` frames from `src` into `out`, laid out interleaved.
+///
+/// `src_skip` and `dst_skip` are the starting frames in the adapter and the
+/// slice. Returns the number of samples clipped during conversion, or `None` if
+/// the region does not fit in either side. See the [module docs](self).
+pub fn to_interleaved<T: Clone>(
+    src: &dyn Adapter<T>,
+    out: &mut [T],
+    src_skip: usize,
+    dst_skip: usize,
+    take: usize,
+) -> Option<usize> {
+    let channels = src.channels();
+    let frames = slice_frames(out.len(), channels);
+    // `frames` is `out.len() / channels`, so `out` is long enough by construction.
+    let mut dst =
+        InterleavedSlice::new_mut(out, channels, frames).expect("out fits channels*frames");
+    dst.copy_from_other(src, src_skip, dst_skip, take)
+}
+
+/// Copy `take` frames from `src` into `out`, laid out sequential (channel by
+/// channel).
+///
+/// `src_skip` and `dst_skip` are the starting frames in the adapter and the
+/// slice. Returns the number of samples clipped during conversion, or `None` if
+/// the region does not fit in either side. See the [module docs](self).
+pub fn to_sequential<T: Clone>(
+    src: &dyn Adapter<T>,
+    out: &mut [T],
+    src_skip: usize,
+    dst_skip: usize,
+    take: usize,
+) -> Option<usize> {
+    let channels = src.channels();
+    let frames = slice_frames(out.len(), channels);
+    let mut dst =
+        SequentialSlice::new_mut(out, channels, frames).expect("out fits channels*frames");
+    dst.copy_from_other(src, src_skip, dst_skip, take)
+}
+
+/// Copy `take` frames from the interleaved slice `input` into the adapter `dst`.
+///
+/// `src_skip` and `dst_skip` are the starting frames in the slice and the
+/// adapter. Returns the number of samples clipped during conversion, or `None`
+/// if the region does not fit in either side. See the [module docs](self).
+pub fn from_interleaved<T: Clone>(
+    input: &[T],
+    dst: &mut dyn AdapterMut<T>,
+    src_skip: usize,
+    dst_skip: usize,
+    take: usize,
+) -> Option<usize> {
+    let channels = dst.channels();
+    let frames = slice_frames(input.len(), channels);
+    let src = InterleavedSlice::new(input, channels, frames).expect("input fits channels*frames");
+    dst.copy_from_other(&src, src_skip, dst_skip, take)
+}
+
+/// Copy `take` frames from the sequential slice `input` (channel by channel)
+/// into the adapter `dst`.
+///
+/// `src_skip` and `dst_skip` are the starting frames in the slice and the
+/// adapter. Returns the number of samples clipped during conversion, or `None`
+/// if the region does not fit in either side. See the [module docs](self).
+pub fn from_sequential<T: Clone>(
+    input: &[T],
+    dst: &mut dyn AdapterMut<T>,
+    src_skip: usize,
+    dst_skip: usize,
+    take: usize,
+) -> Option<usize> {
+    let channels = dst.channels();
+    let frames = slice_frames(input.len(), channels);
+    let src = SequentialSlice::new(input, channels, frames).expect("input fits channels*frames");
+    dst.copy_from_other(&src, src_skip, dst_skip, take)
+}
+
+//   _____         _
+//  |_   _|__  ___| |_ ___
+//    | |/ _ \/ __| __/ __|
+//    | |  __/\__ \ |_\__ \
+//    |_|\___||___/\__|___/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::direct::{InterleavedSlice, SequentialSlice};
+
+    // sequential [ch0: 1,2,3][ch1: 4,5,6]  <->  interleaved [1,4,2,5,3,6]
+
+    #[test]
+    fn adapter_to_interleaved_whole() {
+        let data = [1, 2, 3, 4, 5, 6];
+        let src = SequentialSlice::new(&data, 2, 3).unwrap();
+        let mut out = [0; 6];
+        let clipped = to_interleaved(&src, &mut out, 0, 0, 3);
+        assert_eq!(clipped, Some(0));
+        assert_eq!(out, [1, 4, 2, 5, 3, 6]);
+    }
+
+    #[test]
+    fn adapter_to_sequential_whole() {
+        let data = [1, 4, 2, 5, 3, 6];
+        let src = InterleavedSlice::new(&data, 2, 3).unwrap();
+        let mut out = [0; 6];
+        assert_eq!(to_sequential(&src, &mut out, 0, 0, 3), Some(0));
+        assert_eq!(out, [1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn interleaved_into_adapter_whole() {
+        let input = [1, 4, 2, 5, 3, 6];
+        let mut store = [0; 6];
+        let mut dst = SequentialSlice::new_mut(&mut store, 2, 3).unwrap();
+        assert_eq!(from_interleaved(&input, &mut dst, 0, 0, 3), Some(0));
+        assert_eq!(store, [1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn sequential_into_adapter_whole() {
+        let input = [1, 2, 3, 4, 5, 6];
+        let mut store = [0; 6];
+        let mut dst = InterleavedSlice::new_mut(&mut store, 2, 3).unwrap();
+        assert_eq!(from_sequential(&input, &mut dst, 0, 0, 3), Some(0));
+        assert_eq!(store, [1, 4, 2, 5, 3, 6]);
+    }
+
+    #[test]
+    fn partial_take_copies_a_prefix() {
+        // Source has 3 frames, copy only the first 2 into a 2-frame slice.
+        let data = [1, 2, 3, 4, 5, 6]; // ch0 = [1,2,3], ch1 = [4,5,6]
+        let src = SequentialSlice::new(&data, 2, 3).unwrap();
+        let mut out = [0; 4];
+        assert_eq!(to_interleaved(&src, &mut out, 0, 0, 2), Some(0));
+        assert_eq!(out, [1, 4, 2, 5]);
+    }
+
+    #[test]
+    fn src_skip_reads_from_offset() {
+        let data = [1, 2, 3, 4, 5, 6]; // ch0 = [1,2,3], ch1 = [4,5,6]
+        let src = SequentialSlice::new(&data, 2, 3).unwrap();
+        let mut out = [0; 4];
+        // Skip the first source frame, take the next two: frames 1 and 2.
+        assert_eq!(to_interleaved(&src, &mut out, 1, 0, 2), Some(0));
+        assert_eq!(out, [2, 5, 3, 6]);
+    }
+
+    #[test]
+    fn dst_skip_appends() {
+        // Write one frame at frame 2 of a 3-frame adapter.
+        let mut store = [0; 6];
+        let mut dst = SequentialSlice::new_mut(&mut store, 2, 3).unwrap();
+        let input = [7, 70]; // one interleaved frame: ch0 = 7, ch1 = 70
+        assert_eq!(from_interleaved(&input, &mut dst, 0, 2, 1), Some(0));
+        // ch0 = [0,0,7], ch1 = [0,0,70]
+        assert_eq!(store, [0, 0, 7, 0, 0, 70]);
+    }
+
+    #[test]
+    fn region_that_does_not_fit_returns_none() {
+        let data = [1, 2, 3, 4, 5, 6];
+        let src = SequentialSlice::new(&data, 2, 3).unwrap();
+        let mut out = [0; 4]; // room for 2 frames
+
+        // take larger than the slice can hold
+        assert_eq!(to_interleaved(&src, &mut out, 0, 0, 3), None);
+        // take larger than the source has
+        let mut big = [0; 12]; // room for 6 frames
+        assert_eq!(to_interleaved(&src, &mut big, 0, 0, 4), None);
+        // overflowing skip must not wrap
+        assert_eq!(to_interleaved(&src, &mut out, usize::MAX, 0, 2), None);
+    }
+
+    #[test]
+    fn longer_slice_ignores_trailing_partial_frame() {
+        let data = [1, 2, 3, 4, 5, 6];
+        let src = SequentialSlice::new(&data, 2, 3).unwrap();
+        let mut ragged = [0; 5]; // holds 2 whole frames, 1 trailing sample unused
+        assert_eq!(to_interleaved(&src, &mut ragged, 0, 0, 2), Some(0));
+        assert_eq!(ragged, [1, 4, 2, 5, 0]); // last element untouched
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn sparse_source_reads_zeros_for_absent_channels() {
+        use crate::direct::SparseSequentialSliceOfVecs;
+        extern crate alloc;
+        use alloc::vec;
+
+        // 2 channels, 3 frames, but only channel 0 is present.
+        let data = vec![vec![1, 2, 3], vec![]];
+        let mask = [true, false];
+        let src = SparseSequentialSliceOfVecs::new(&data, 2, 3, &mask).unwrap();
+
+        let mut out = [9; 6];
+        assert_eq!(to_interleaved(&src, &mut out, 0, 0, 3), Some(0));
+        // ch1 reads as default (0): frames [ch0, ch1] = [1,0],[2,0],[3,0]
+        assert_eq!(out, [1, 0, 2, 0, 3, 0]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn sparse_destination_drops_absent_channels() {
+        use crate::direct::SparseSequentialSliceOfVecs;
+        extern crate alloc;
+        use alloc::vec;
+
+        // 2 channels, 3 frames, only channel 0 is writable.
+        let mut data = vec![vec![0, 0, 0], vec![0, 0, 0]];
+        let mask = [true, false];
+        let mut dst = SparseSequentialSliceOfVecs::new_mut(&mut data, 2, 3, &mask).unwrap();
+
+        // interleaved input: ch0 = [1,2,3], ch1 = [10,20,30]
+        let input = [1, 10, 2, 20, 3, 30];
+        assert_eq!(from_interleaved(&input, &mut dst, 0, 0, 3), Some(0));
+        // ch0 was written, ch1 writes were dropped (vector left untouched).
+        assert_eq!(data[0], [1, 2, 3]);
+        assert_eq!(data[1], [0, 0, 0]);
+    }
+
+    #[test]
+    fn from_interleaved_reports_clipping() {
+        use crate::adapter_to_float::ConvertNumbers;
+        use audioadapter::AdapterMut;
+
+        // A float-to-i16 converting destination: values outside [-1, 1] clip.
+        let mut store = [0i16; 2];
+        {
+            let mut inner = InterleavedSlice::new_mut(&mut store, 1, 2).unwrap();
+            let mut dst: ConvertNumbers<&mut dyn AdapterMut<i16>, f32> =
+                ConvertNumbers::new_mut(&mut inner as &mut dyn AdapterMut<i16>);
+            // Both samples are well above full scale, so both clip on the way in.
+            let input = [2.0_f32, 2.0];
+            assert_eq!(from_interleaved(&input, &mut dst, 0, 0, 2), Some(2));
+        }
+        // Both samples saturated to the i16 maximum.
+        assert_eq!(store, [i16::MAX, i16::MAX]);
+    }
+}

--- a/audioadapter-buffers/src/utils.rs
+++ b/audioadapter-buffers/src/utils.rs
@@ -50,7 +50,8 @@ use crate::direct::{InterleavedSlice, SequentialSlice};
 /// Number of whole frames a flat slice of `len` samples holds for `channels`
 /// channels. Zero channels yields zero frames rather than dividing by zero.
 fn slice_frames(len: usize, channels: usize) -> usize {
-    if channels == 0 { 0 } else { len / channels }
+    // `checked_div` yields `None` for zero channels, which we treat as zero frames.
+    len.checked_div(channels).unwrap_or(0)
 }
 
 /// Copy `take` frames from `src` into `out`, laid out interleaved.

--- a/audioadapter-sample/Cargo.toml
+++ b/audioadapter-sample/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter-sample"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]

--- a/audioadapter-sample/src/readwrite.rs
+++ b/audioadapter-sample/src/readwrite.rs
@@ -24,7 +24,10 @@ pub trait ReadSamples: io::Read {
     /// * The underlying reader returns an error.
     /// * The number of bytes read is not sufficient to represent a complete sample.
     fn read_sample<T: BytesSample>(&mut self) -> io::Result<T> {
-        let mut sample: T = unsafe { std::mem::zeroed() };
+        // Start from a valid, correctly sized sample and read straight into its
+        // bytes. Using `T::zero()` rather than `mem::zeroed` keeps this sound
+        // for any `T`, since `zero` is a safe, implementor-provided constructor.
+        let mut sample = T::zero();
         self.read_exact(sample.as_mut_slice())?;
         Ok(sample)
     }

--- a/audioadapter-sample/src/sample.rs
+++ b/audioadapter-sample/src/sample.rs
@@ -218,6 +218,13 @@ pub trait BytesSample {
     /// The number of bytes making up each sample value.
     const BYTES_PER_SAMPLE: usize;
 
+    /// Create a sample with all bytes set to zero.
+    ///
+    /// This gives a correctly sized, valid value whose bytes can then be
+    /// overwritten, for example via [`as_mut_slice`](Self::as_mut_slice) when
+    /// reading from a stream.
+    fn zero() -> Self;
+
     /// Create a new ByteSample from a slice of raw bytes.
     /// The slice length must be at least the number of bytes
     /// for a sample value.
@@ -310,6 +317,10 @@ impl BytesSample for I24_4RJ_LE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -339,6 +350,10 @@ impl BytesSample for I24_4LJ_LE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -366,6 +381,10 @@ impl BytesSample for I24_4LJ_LE {
 impl BytesSample for I24_LE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
+
+    fn zero() -> Self {
+        Self(Default::default())
+    }
 
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..3].try_into().unwrap())
@@ -396,6 +415,10 @@ impl BytesSample for I24_4RJ_BE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -425,6 +448,10 @@ impl BytesSample for I24_4LJ_BE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -452,6 +479,10 @@ impl BytesSample for I24_4LJ_BE {
 impl BytesSample for I24_BE {
     type NumericType = i32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
+
+    fn zero() -> Self {
+        Self(Default::default())
+    }
 
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..3].try_into().unwrap())
@@ -482,6 +513,10 @@ impl BytesSample for U24_4RJ_LE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -511,6 +546,10 @@ impl BytesSample for U24_4LJ_LE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -538,6 +577,10 @@ impl BytesSample for U24_4LJ_LE {
 impl BytesSample for U24_LE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
+
+    fn zero() -> Self {
+        Self(Default::default())
+    }
 
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..3].try_into().unwrap())
@@ -568,6 +611,10 @@ impl BytesSample for U24_4RJ_BE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -597,6 +644,10 @@ impl BytesSample for U24_4LJ_BE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
 
+    fn zero() -> Self {
+        Self(Default::default())
+    }
+
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..4].try_into().unwrap())
     }
@@ -624,6 +675,10 @@ impl BytesSample for U24_4LJ_BE {
 impl BytesSample for U24_BE {
     type NumericType = u32;
     const BYTES_PER_SAMPLE: usize = core::mem::size_of::<Self>();
+
+    fn zero() -> Self {
+        Self(Default::default())
+    }
 
     fn from_slice(bytes: &[u8]) -> Self {
         Self(bytes[0..3].try_into().unwrap())
@@ -653,6 +708,10 @@ macro_rules! bytessample_for_newtype {
         impl BytesSample for $newtype {
             type NumericType = $type;
             const BYTES_PER_SAMPLE: usize = core::mem::size_of::<$type>();
+
+            fn zero() -> Self {
+                Self(Default::default())
+            }
 
             fn from_slice(bytes: &[u8]) -> Self {
                 Self(bytes.try_into().unwrap())

--- a/audioadapter/Cargo.toml
+++ b/audioadapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]

--- a/audioadapter/Cargo.toml
+++ b/audioadapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioadapter"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["HEnquist <henrik.enquist@gmail.com>"]

--- a/audioadapter/examples/custom_adapter.rs
+++ b/audioadapter/examples/custom_adapter.rs
@@ -11,7 +11,9 @@ use num_traits::Zero;
 use std::str::FromStr;
 
 struct MyStruct<T> {
-    _phantom: core::marker::PhantomData<T>,
+    // `MyStruct` produces `T` from strings on read but never stores one, so use
+    // a `fn() -> T` marker rather than `PhantomData<T>` to avoid implying ownership.
+    _phantom: core::marker::PhantomData<fn() -> T>,
     data: Vec<String>,
     channels: usize,
 }

--- a/audioadapter/examples/custom_adapter.rs
+++ b/audioadapter/examples/custom_adapter.rs
@@ -10,15 +10,15 @@ use audioadapter::Adapter;
 use num_traits::Zero;
 use std::str::FromStr;
 
-struct MyStruct<'a, T> {
-    _phantom: core::marker::PhantomData<&'a T>,
+struct MyStruct<T> {
+    _phantom: core::marker::PhantomData<T>,
     data: Vec<String>,
     channels: usize,
 }
 
-unsafe impl<'a, T> Adapter<'a, T> for MyStruct<'a, T>
+unsafe impl<T> Adapter<T> for MyStruct<T>
 where
-    T: Clone + FromStr + Zero + 'a,
+    T: Clone + FromStr + Zero,
 {
     fn channels(&self) -> usize {
         self.channels
@@ -43,7 +43,7 @@ fn main() {
         "5".to_owned(),
         "6".to_owned(),
     ];
-    let adapter: MyStruct<'_, f32> = MyStruct {
+    let adapter: MyStruct<f32> = MyStruct {
         _phantom: core::marker::PhantomData,
         data,
         channels: 2,

--- a/audioadapter/src/audio.rs
+++ b/audioadapter/src/audio.rs
@@ -7,9 +7,9 @@ use crate::{Adapter, AdapterMut};
 
 use audio_core::{Buf, BufMut, Channel, ChannelMut, ExactSizeBuf, Sample};
 
-unsafe impl<'a, T, U> Adapter<'a, T> for U
+unsafe impl<T, U> Adapter<T> for U
 where
-    T: Clone + Sample + 'a,
+    T: Clone + Sample,
     U: Buf<Sample = T> + ExactSizeBuf<Sample = T>,
 {
     fn channels(&self) -> usize {
@@ -43,9 +43,9 @@ where
     }
 }
 
-unsafe impl<'a, T, U> AdapterMut<'a, T> for U
+unsafe impl<T, U> AdapterMut<T> for U
 where
-    T: Clone + Sample + 'a,
+    T: Clone + Sample,
     U: BufMut<Sample = T> + ExactSizeBuf<Sample = T>,
 {
     unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &T) -> bool {

--- a/audioadapter/src/iterators.rs
+++ b/audioadapter/src/iterators.rs
@@ -4,64 +4,61 @@ use crate::Adapter;
 
 /// A trait providing convenient iteration through frames and/or channels
 /// of an [Adapter].
-pub trait AdapterIterators<'a, T: 'a> {
+pub trait AdapterIterators<T> {
     /// Get an iterator that yields the sample value of the specified channel.
-    fn iter_channel(&self, channel: usize) -> Option<ChannelSamples<'a, '_, T>>;
+    fn iter_channel(&self, channel: usize) -> Option<ChannelSamples<'_, T>>;
 
     /// Get an iterator that yields iterators for the channels.
-    fn iter_channels(&self) -> Channels<'a, '_, T>;
+    fn iter_channels(&self) -> Channels<'_, T>;
 
     /// Get an iterator that yields the sample values of the specified frame.
-    fn iter_frame(&self, frame: usize) -> Option<FrameSamples<'a, '_, T>>;
+    fn iter_frame(&self, frame: usize) -> Option<FrameSamples<'_, T>>;
 
     /// Get an iterator that yields iterators for the frames.
-    fn iter_frames(&self) -> Frames<'a, '_, T>;
+    fn iter_frames(&self) -> Frames<'_, T>;
 }
 
-impl<'a, T, U> AdapterIterators<'a, T> for U
+impl<T, U> AdapterIterators<T> for U
 where
-    T: Clone + 'a,
-    U: Adapter<'a, T>,
+    T: Clone,
+    U: Adapter<T>,
 {
-    fn iter_channel(&self, channel: usize) -> Option<ChannelSamples<'a, '_, T>> {
+    fn iter_channel(&self, channel: usize) -> Option<ChannelSamples<'_, T>> {
         ChannelSamples::new(self, channel)
     }
 
-    fn iter_channels(&self) -> Channels<'a, '_, T> {
+    fn iter_channels(&self) -> Channels<'_, T> {
         Channels::new(self)
     }
 
-    fn iter_frame(&self, frame: usize) -> Option<FrameSamples<'a, '_, T>> {
+    fn iter_frame(&self, frame: usize) -> Option<FrameSamples<'_, T>> {
         FrameSamples::new(self, frame)
     }
 
-    fn iter_frames(&self) -> Frames<'a, '_, T> {
+    fn iter_frames(&self) -> Frames<'_, T> {
         Frames::new(self)
     }
 }
 
 /// An iterator that yields the sample values of a channel.
-pub struct ChannelSamples<'a, 'b, T> {
-    buf: &'b dyn Adapter<'a, T>,
+pub struct ChannelSamples<'b, T> {
+    buf: &'b dyn Adapter<T>,
     frame: usize,
     nbr_frames: usize,
     channel: usize,
 }
 
-impl<'a, 'b, T> ChannelSamples<'a, 'b, T>
+impl<'b, T> ChannelSamples<'b, T>
 where
     T: Clone,
 {
-    pub fn new(
-        buffer: &'b dyn Adapter<'a, T>,
-        channel: usize,
-    ) -> Option<ChannelSamples<'a, 'b, T>> {
+    pub fn new(buffer: &'b dyn Adapter<T>, channel: usize) -> Option<ChannelSamples<'b, T>> {
         if channel >= buffer.channels() {
             return None;
         }
         let nbr_frames = buffer.frames();
         Some(ChannelSamples {
-            buf: buffer as &'b dyn Adapter<'a, T>,
+            buf: buffer as &'b dyn Adapter<T>,
             frame: 0,
             nbr_frames,
             channel,
@@ -69,7 +66,7 @@ where
     }
 }
 
-impl<T> Iterator for ChannelSamples<'_, '_, T>
+impl<T> Iterator for ChannelSamples<'_, T>
 where
     T: Clone,
 {
@@ -86,24 +83,24 @@ where
 }
 
 /// An iterator that yields the samples values of a frame.
-pub struct FrameSamples<'a, 'b, T> {
-    buf: &'b dyn Adapter<'a, T>,
+pub struct FrameSamples<'b, T> {
+    buf: &'b dyn Adapter<T>,
     frame: usize,
     nbr_channels: usize,
     channel: usize,
 }
 
-impl<'a, 'b, T> FrameSamples<'a, 'b, T>
+impl<'b, T> FrameSamples<'b, T>
 where
     T: Clone,
 {
-    pub fn new(buffer: &'b dyn Adapter<'a, T>, frame: usize) -> Option<FrameSamples<'a, 'b, T>> {
+    pub fn new(buffer: &'b dyn Adapter<T>, frame: usize) -> Option<FrameSamples<'b, T>> {
         if frame >= buffer.frames() {
             return None;
         }
         let nbr_channels = buffer.channels();
         Some(FrameSamples {
-            buf: buffer as &'b dyn Adapter<'a, T>,
+            buf: buffer as &'b dyn Adapter<T>,
             channel: 0,
             nbr_channels,
             frame,
@@ -111,7 +108,7 @@ where
     }
 }
 
-impl<T> Iterator for FrameSamples<'_, '_, T>
+impl<T> Iterator for FrameSamples<'_, T>
 where
     T: Clone,
 {
@@ -130,31 +127,31 @@ where
 // -------------------- Iterators returning immutable iterators --------------------
 
 /// An iterator that yields a [ChannelSamples] iterator for each channel of an [Adapter].
-pub struct Channels<'a, 'b, T> {
-    buf: &'b dyn Adapter<'a, T>,
+pub struct Channels<'b, T> {
+    buf: &'b dyn Adapter<T>,
     nbr_channels: usize,
     channel: usize,
 }
 
-impl<'a, 'b, T> Channels<'a, 'b, T>
+impl<'b, T> Channels<'b, T>
 where
     T: Clone,
 {
-    pub fn new(buffer: &'b dyn Adapter<'a, T>) -> Channels<'a, 'b, T> {
+    pub fn new(buffer: &'b dyn Adapter<T>) -> Channels<'b, T> {
         let nbr_channels = buffer.channels();
         Channels {
-            buf: buffer as &'b dyn Adapter<'a, T>,
+            buf: buffer as &'b dyn Adapter<T>,
             channel: 0,
             nbr_channels,
         }
     }
 }
 
-impl<'a, 'b, T> Iterator for Channels<'a, 'b, T>
+impl<'b, T> Iterator for Channels<'b, T>
 where
     T: Clone,
 {
-    type Item = ChannelSamples<'a, 'b, T>;
+    type Item = ChannelSamples<'b, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.channel >= self.nbr_channels {
@@ -167,31 +164,31 @@ where
 }
 
 /// An iterator that yields a [FrameSamples] iterator for each frame of an [Adapter].
-pub struct Frames<'a, 'b, T> {
-    buf: &'b dyn Adapter<'a, T>,
+pub struct Frames<'b, T> {
+    buf: &'b dyn Adapter<T>,
     nbr_frames: usize,
     frame: usize,
 }
 
-impl<'a, 'b, T> Frames<'a, 'b, T>
+impl<'b, T> Frames<'b, T>
 where
     T: Clone,
 {
-    pub fn new(buffer: &'b dyn Adapter<'a, T>) -> Frames<'a, 'b, T> {
+    pub fn new(buffer: &'b dyn Adapter<T>) -> Frames<'b, T> {
         let nbr_frames = buffer.frames();
         Frames {
-            buf: buffer as &'b dyn Adapter<'a, T>,
+            buf: buffer as &'b dyn Adapter<T>,
             frame: 0,
             nbr_frames,
         }
     }
 }
 
-impl<'a, 'b, T> Iterator for Frames<'a, 'b, T>
+impl<'b, T> Iterator for Frames<'b, T>
 where
     T: Clone,
 {
-    type Item = FrameSamples<'a, 'b, T>;
+    type Item = FrameSamples<'b, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.frame >= self.nbr_frames {

--- a/audioadapter/src/lib.rs
+++ b/audioadapter/src/lib.rs
@@ -46,9 +46,9 @@ pub mod tests {
         }
     }
 
-    unsafe impl<'a, T> Adapter<'a, T> for MinimalAdapter<T>
+    unsafe impl<T> Adapter<T> for MinimalAdapter<T>
     where
-        T: Clone + 'a,
+        T: Clone,
     {
         unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> T {
             let index = frame * self.channels + channel;
@@ -64,9 +64,9 @@ pub mod tests {
         }
     }
 
-    unsafe impl<'a, T> AdapterMut<'a, T> for MinimalAdapter<T>
+    unsafe impl<T> AdapterMut<T> for MinimalAdapter<T>
     where
-        T: Clone + 'a,
+        T: Clone,
     {
         unsafe fn write_sample_unchecked(
             &mut self,
@@ -87,9 +87,9 @@ pub mod tests {
     /// It takes a mutable reference to an adapter and runs a series of tests.
     /// The adapter is expected to have at least 2 channels and 4 frames.
     /// The sample type `T` must support `Default`, `Clone`, `PartialEq`, `Debug`, and be convertible to and from `usize`.
-    pub fn test_adapter_mut_methods<'a, T>(buffer: &mut dyn AdapterMut<'a, T>)
+    pub fn test_adapter_mut_methods<T>(buffer: &mut dyn AdapterMut<T>)
     where
-        T: Default + Clone + PartialEq + core::fmt::Debug + From<usize> + Into<usize> + 'a,
+        T: Default + Clone + PartialEq + core::fmt::Debug + From<usize> + Into<usize>,
     {
         // Ensure buffer is large enough for tests
         assert!(
@@ -200,9 +200,9 @@ pub mod tests {
     /// It takes a mutable reference to an adapter and runs a series of tests.
     /// The adapter is expected to have at least 2 channels and 4 frames.
     /// The sample type `T` must be a floating-point type implementing `FloatCore`, `NumCast`, `Default`, `Clone`, `PartialEq`, and `Debug`.
-    pub fn test_float_adapter_mut_methods<'a, T>(buffer: &mut dyn AdapterMut<'a, T>)
+    pub fn test_float_adapter_mut_methods<T>(buffer: &mut dyn AdapterMut<T>)
     where
-        T: FloatCore + NumCast + Default + Clone + PartialEq + core::fmt::Debug + 'a,
+        T: FloatCore + NumCast + Default + Clone + PartialEq + core::fmt::Debug,
     {
         // Helper for approximate float comparison
         let assert_approx_eq = |a: T, b: T, message: &str| {

--- a/audioadapter/src/stats.rs
+++ b/audioadapter/src/stats.rs
@@ -45,9 +45,9 @@ fn sqrt_newton(value: f64) -> f64 {
 /// This requires that the samples are of a numerical type, that implement the
 /// [num_traits::ToPrimitive], [num_traits::Num] and [core::cmp::PartialOrd] traits.
 /// This includes all the built in numerical types such as `i16`, `i32`, `f32` etc.
-pub trait AdapterStats<'a, T>: Adapter<'a, T>
+pub trait AdapterStats<T>: Adapter<T>
 where
-    T: Clone + ToPrimitive + Num + PartialOrd + 'a,
+    T: Clone + ToPrimitive + Num + PartialOrd,
 {
     /// Calculate the RMS value of the given channel.
     /// The result is returned as `f64`.
@@ -140,10 +140,10 @@ where
     }
 }
 
-impl<'a, T, U> AdapterStats<'a, T> for U
+impl<T, U> AdapterStats<T> for U
 where
-    T: Clone + ToPrimitive + Num + PartialOrd + 'a,
-    U: Adapter<'a, T>,
+    T: Clone + ToPrimitive + Num + PartialOrd,
+    U: Adapter<T>,
 {
 }
 

--- a/audioadapter/src/traits.rs
+++ b/audioadapter/src/traits.rs
@@ -243,10 +243,13 @@ where
         self_skip: usize,
         take: usize,
     ) -> Option<usize> {
+        // Overflow-safe form of `take + self_skip > self.frames()` etc.
         if self_channel >= self.channels()
-            || take + self_skip > self.frames()
+            || take > self.frames()
+            || self_skip > self.frames() - take
             || other_channel >= other.channels()
-            || take + other_skip > other.frames()
+            || take > other.frames()
+            || other_skip > other.frames() - take
         {
             return None;
         }
@@ -294,7 +297,9 @@ where
     /// or to initialize each sample to a certain value.
     /// Returns `None` if called with a too large range.
     fn fill_frames_with(&mut self, start: usize, count: usize, value: &T) -> Option<usize> {
-        if start + count >= self.frames() {
+        // Overflow-safe form of `start + count > frames`. Previously used `>=`,
+        // which wrongly rejected a fill whose range ends exactly at `frames`.
+        if count > self.frames() || start > self.frames() - count {
             return None;
         }
         for channel in 0..self.channels() {
@@ -322,7 +327,8 @@ where
     /// The default implementation copies by calling the read and write methods,
     /// while type specific implementations can use more efficient methods.
     fn copy_frames_within(&mut self, src: usize, dest: usize, count: usize) -> Option<usize> {
-        if src + count > self.frames() || dest + count > self.frames() {
+        // Overflow-safe form of `src + count > frames || dest + count > frames`.
+        if count > self.frames() || src > self.frames() - count || dest > self.frames() - count {
             return None;
         }
         if count == 0 || src == dest {
@@ -638,5 +644,44 @@ mod tests {
 
         // OOB
         assert!(!buffer.swap_samples(0, 0, 2, 0));
+    }
+
+    #[test]
+    fn copy_frames_within_rejects_overflowing_range() {
+        let mut buffer = dummy_adapter(); // 2 channels, 4 frames
+        // src + count and dest + count would wrap; must return None, not UB.
+        assert_eq!(buffer.copy_frames_within(usize::MAX, 0, 2), None);
+        assert_eq!(buffer.copy_frames_within(0, usize::MAX, 2), None);
+        assert_eq!(buffer.copy_frames_within(0, 0, usize::MAX), None);
+    }
+
+    #[test]
+    fn copy_from_other_rejects_overflowing_range() {
+        let mut buffer = dummy_adapter();
+        let other = dummy_adapter();
+        // take + skip would wrap; must return None, not index out of bounds.
+        assert_eq!(
+            buffer.copy_from_other_to_channel(&other, 0, 0, usize::MAX, 0, 2),
+            None
+        );
+        assert_eq!(
+            buffer.copy_from_other_to_channel(&other, 0, 0, 0, usize::MAX, 2),
+            None
+        );
+    }
+
+    #[test]
+    fn fill_frames_with_allows_full_range() {
+        // Filling the whole frame range (start + count == frames) is valid and
+        // must succeed. The old `>=` guard wrongly rejected this.
+        let mut buffer = dummy_adapter(); // 4 frames
+        assert_eq!(buffer.fill_frames_with(0, 4, &9), Some(4));
+        for f in 0..4 {
+            assert_eq!(buffer.read_sample(0, f), Some(9));
+            assert_eq!(buffer.read_sample(1, f), Some(9));
+        }
+        // Past the end is still rejected, including the overflowing case.
+        assert_eq!(buffer.fill_frames_with(0, 5, &9), None);
+        assert_eq!(buffer.fill_frames_with(usize::MAX, 2, &9), None);
     }
 }

--- a/audioadapter/src/traits.rs
+++ b/audioadapter/src/traits.rs
@@ -22,7 +22,7 @@
 /// use these bounds before calling `read_sample_unchecked` internally.
 /// If the reported bounds are wrong, those internal unchecked accesses can become
 /// out of bounds and cause undefined behavior.
-pub unsafe trait Adapter<'a, T: 'a> {
+pub unsafe trait Adapter<T> {
     /// Read the sample at
     /// a given combination of frame and channel.
     ///
@@ -118,9 +118,9 @@ pub unsafe trait Adapter<'a, T: 'a> {
 /// use these bounds before calling `write_sample_unchecked` internally.
 /// If the reported bounds are wrong, those internal unchecked accesses can become
 /// out of bounds and cause undefined behavior.
-pub unsafe trait AdapterMut<'a, T>: Adapter<'a, T>
+pub unsafe trait AdapterMut<T>: Adapter<T>
 where
-    T: Clone + 'a,
+    T: Clone,
 {
     /// Write a sample to the
     /// given combination of frame and channel.
@@ -236,7 +236,7 @@ where
     /// no values will be copied and `None` is returned.
     fn copy_from_other_to_channel(
         &mut self,
-        other: &dyn Adapter<'a, T>,
+        other: &dyn Adapter<T>,
         other_channel: usize,
         self_channel: usize,
         other_skip: usize,

--- a/audioadapter/src/traits.rs
+++ b/audioadapter/src/traits.rs
@@ -264,6 +264,45 @@ where
         Some(nbr_clipped)
     }
 
+    /// Copy values from another Adapter into self.
+    /// The `self_skip` and `other_skip` arguments are the offsets
+    /// in frames for where copying starts in the two buffers.
+    /// The method copies `take` frames for all channels in `other`.
+    ///
+    /// The source buffer must have no more channels than self.
+    /// Any extra channels in self are left unchanged.
+    ///
+    /// Returns the number of values that were clipped during conversion.
+    /// Implementations that do not perform any conversion
+    /// always return zero clipped samples.
+    ///
+    /// If the source buffer has more channels than self,
+    /// or if either buffer is too short to copy `take` frames,
+    /// no values will be copied and `None` is returned.
+    fn copy_from_other(
+        &mut self,
+        other: &dyn Adapter<T>,
+        other_skip: usize,
+        self_skip: usize,
+        take: usize,
+    ) -> Option<usize> {
+        // Overflow-safe form of `take + self_skip > self.frames()` etc.
+        if other.channels() > self.channels()
+            || take > self.frames()
+            || self_skip > self.frames() - take
+            || take > other.frames()
+            || other_skip > other.frames() - take
+        {
+            return None;
+        }
+        let mut nbr_clipped = 0;
+        for channel in 0..other.channels() {
+            nbr_clipped += self
+                .copy_from_other_to_channel(other, channel, channel, other_skip, self_skip, take)?;
+        }
+        Some(nbr_clipped)
+    }
+
     /// Write the provided value to every sample in a channel.
     /// Can be used to clear a channel by writing zeroes,
     /// or to initialize each sample to a certain value.
@@ -537,6 +576,74 @@ mod tests {
         assert_eq!(buffer.read_sample(0, 1), Some(3));
         assert_eq!(buffer.read_sample(0, 2), Some(5));
         assert_eq!(buffer.read_sample(0, 3), Some(7));
+    }
+
+    #[test]
+    fn copy_from_other() {
+        let mut buffer = dummy_adapter();
+        let other = dummy_adapter();
+        // Copy 2 frames of all channels, starting at frame 1 in other.
+        // other ch0: [1, 2, 4, 6], ch1: [1, 3, 5, 7]
+        // taking frames 1..3 gives ch0: [2, 4], ch1: [3, 5]
+        let clipped = buffer.copy_from_other(&other, 1, 0, 2);
+        assert_eq!(clipped, Some(0));
+        // ch0 was [1, 2, 4, 6], now [2, 4, 4, 6]
+        assert_eq!(buffer.read_sample(0, 0), Some(2));
+        assert_eq!(buffer.read_sample(0, 1), Some(4));
+        assert_eq!(buffer.read_sample(0, 2), Some(4));
+        assert_eq!(buffer.read_sample(0, 3), Some(6));
+        // ch1 was [1, 3, 5, 7], now [3, 5, 5, 7]
+        assert_eq!(buffer.read_sample(1, 0), Some(3));
+        assert_eq!(buffer.read_sample(1, 1), Some(5));
+        assert_eq!(buffer.read_sample(1, 2), Some(5));
+        assert_eq!(buffer.read_sample(1, 3), Some(7));
+    }
+
+    #[test]
+    fn copy_from_other_fewer_channels_leaves_extra_unchanged() {
+        let mut buffer = dummy_adapter(); // 2 channels, 4 frames
+        // A single-channel source: ch0 is [10, 20, 30, 40].
+        let narrow = MinimalAdapter::new_from_vec(vec![10_i32, 20, 30, 40], 1, 4);
+        let clipped = buffer.copy_from_other(&narrow, 0, 0, 4);
+        assert_eq!(clipped, Some(0));
+        // ch0 is overwritten
+        assert_eq!(buffer.read_sample(0, 0), Some(10));
+        assert_eq!(buffer.read_sample(0, 3), Some(40));
+        // ch1 is left as it was: [1, 3, 5, 7]
+        assert_eq!(buffer.read_sample(1, 0), Some(1));
+        assert_eq!(buffer.read_sample(1, 3), Some(7));
+    }
+
+    #[test]
+    fn copy_from_other_rejects_too_many_channels() {
+        let mut buffer = dummy_adapter(); // 2 channels
+        // Source has 3 channels, more than self: must refuse.
+        let wide = MinimalAdapter::new_from_vec(vec![0_i32; 12], 3, 4);
+        assert_eq!(buffer.copy_from_other(&wide, 0, 0, 1), None);
+    }
+
+    #[test]
+    fn copy_from_other_rejects_invalid_range() {
+        let mut buffer = dummy_adapter(); // 2 channels, 4 frames
+        let other = dummy_adapter();
+        // take longer than the buffers.
+        assert_eq!(buffer.copy_from_other(&other, 0, 0, 5), None);
+        // take + skip would wrap; must return None, not index out of bounds.
+        assert_eq!(buffer.copy_from_other(&other, 0, usize::MAX, 2), None);
+        assert_eq!(buffer.copy_from_other(&other, usize::MAX, 0, 2), None);
+    }
+
+    #[test]
+    fn copy_from_other_skip_boundary() {
+        let mut buffer = dummy_adapter(); // 2 channels, 4 frames
+        let other = dummy_adapter();
+        // skip == frames - take is the largest valid offset and must be accepted.
+        assert!(buffer.copy_from_other(&other, 2, 2, 2).is_some());
+        // one past that on either side is rejected, not accepted via a `>=` slip.
+        assert_eq!(buffer.copy_from_other(&other, 0, 3, 2), None);
+        assert_eq!(buffer.copy_from_other(&other, 3, 0, 2), None);
+        // take == 0 is a valid no-op even at the very end of the buffer.
+        assert_eq!(buffer.copy_from_other(&other, 4, 4, 0), Some(0));
     }
 
     #[test]


### PR DESCRIPTION
Coordinated 4.0 release for all three crates, assembled on `release/4.0`. All three go to **4.0.0** together (`audioadapter`, `audioadapter-buffers`, `audioadapter-sample`, each was 3.0.0 on `master`).

This bundles four already-reviewed PRs that landed on the integration branch:

## #43 — Byte-slice soundness (`audioadapter-buffers`, `audioadapter-sample`)
- Make the byte-slice constructors sound; replace an unsound transmute path.
- Replace the `BytesSample` byte bound with an `unsafe PlainBytes` trait.
- Add a compile-time alignment assert to the byte transmutes.
- `audioadapter-sample` gains `BytesSample::zero` and bumps to 4.0.0.

## #44 — Overflow & zeroed-read hardening (`audioadapter`)
- Reject integer overflow in the `Adapter`/`AdapterMut` size and copy bounds checks, switching to overflow-safe forms (`take > frames || skip > frames - take`) so large `take`/`skip` values are rejected rather than wrapping.
- Replace `mem::zeroed` in `read_sample` with a `BytesSample::zero` method (no more zeroed reads of arbitrary types).

## #45 — Remove the vestigial `'a` lifetime from the core traits
- `Adapter<'a, T: 'a>` → `Adapter<T>`, `AdapterMut<'a, T> where T: Clone + 'a` → `AdapterMut<T> where T: Clone`. The lifetime was dead since reads became value-returning.
- Iterators collapse from two lifetimes to one; the buffers converters lose the doubled lifetime; redundant `T: 'a` bounds dropped. This is the headline breaking change driving the major bump.

## #46 — `copy_from_other` + a `utils` module of slice-copy helpers
- New `copy_from_other` default method on `AdapterMut` (copies all channels from another adapter), realizing the idea from the discussion in #41 as a lean core primitive rather than baking layout knowledge into the trait.
- New `audioadapter-buffers::utils` module with `to_interleaved`/`to_sequential`/`from_interleaved`/`from_sequential`, thin wrappers that mirror `copy_from_other` and just wrap the plain slice for you. One side is an arbitrary adapter, so they handle relayout and format conversion, and sparse buffers compose cleanly (zero-fill on read, drop on write).

## Versioning
- `audioadapter` 3.0.0 → **4.0.0** (breaking trait change)
- `audioadapter-buffers` 3.0.0 → **4.0.0** (PlainBytes soundness work)
- `audioadapter-sample` 3.0.0 → **4.0.0** (`zero()` addition)

## Verification
Each PR was reviewed and CI-green on `release/4.0`. The branch passes `cargo test --workspace --all-features`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clippy 1.96), and `cargo doc -D warnings`, including the `no_std` / `--no-default-features` and `--features alloc` build paths.